### PR TITLE
Added the export to dataframe from within a TdmsObject.

### DIFF
--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -670,6 +670,19 @@ class TdmsObject(object):
             else:
                 self.data.extend(new_data)
 
+    def as_dataframe(self):
+        """
+        Converts the TDMS object to a DataFrame
+        :return: The TDMS object data.
+        :rtype: Pandas DataFrame
+        """
+
+        import pandas as pd
+
+        return pd.DataFrame(self.data,
+                index=self.time_track(),
+                columns=[self.path])
+
 
 class _TdmsSegmentObject(object):
     """


### PR DESCRIPTION
Objects like channels (tested on a channel) can now be exported as a
pandas dataframe.

This fixes issue #25, which I created earlier today.

I tested it on two tdms files I have here.