### PR TITLE
Added option to TdmsObject.as_dataframe to use absolute times

### DIFF
--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -685,7 +685,7 @@ class TdmsObject(object):
             else:
                 self.data.extend(new_data)
 
-    def as_dataframe(self):
+    def as_dataframe(self, absoluteTime=False):
         """
         Converts the TDMS object to a DataFrame
         :return: The TDMS object data.
@@ -694,8 +694,13 @@ class TdmsObject(object):
 
         import pandas as pd
 
+        # When absoluteTime is True, use the wf_start_time as offset for the time_track()
+        time = (pd.to_datetime(self.property("wf_start_time")) 
+                + pd.to_timedelta(self.time_track(),unit="s") if absoluteTime 
+                else self.time_track())
+
         return pd.DataFrame(self.data,
-                index=self.time_track(),
+                index=time,
                 columns=[self.path])
 
 

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -648,6 +648,30 @@ class TdmsObject(object):
                 offset + (len(self.data) - 1) * increment,
                 len(self.data))
 
+    def pandas_time_track(self):
+        """Return an array of absolute time for this channel
+
+        This depends on the object having the wf_increment
+        and wf_start_offset properties defined.
+
+        :rtype: pandas Series.
+        :raises: KeyError if required properties aren't found
+
+        """
+
+        import pandas as pd
+
+        try:
+            increment = self.property('wf_increment')
+            offset = pd.to_timedelta(self.property('wf_start_offset'), unit='s')
+            starttime = self.property('wf_start_time')
+        except KeyError:
+            raise KeyError("Object does not have time properties available.")
+
+        return pd.date_range(start=offset + pd.to_datetime(starttime), 
+                periods=len(self.data), 
+                freq=str(increment*1e6)+'U')
+
     def _initialise_data(self, memmap_dir=None):
         """Initialise data array to zeros"""
 
@@ -695,8 +719,7 @@ class TdmsObject(object):
         import pandas as pd
 
         # When absoluteTime is True, use the wf_start_time as offset for the time_track()
-        time = (pd.to_datetime(self.property("wf_start_time")) 
-                + pd.to_timedelta(self.time_track(),unit="s") if absoluteTime 
+        time = (self.pandas_time_track() if absoluteTime 
                 else self.time_track())
 
         return pd.DataFrame(self.data,

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -670,7 +670,7 @@ class TdmsObject(object):
 
         return pd.date_range(start=offset + pd.to_datetime(starttime), 
                 periods=len(self.data), 
-                freq=str(increment*1e6)+'U')
+                freq=str(int(increment*1e6))+'U')
 
     def _initialise_data(self, memmap_dir=None):
         """Initialise data array to zeros"""


### PR DESCRIPTION
Added option to TdmsObject.as_dataframe to use absolute times instead of relative times generated by time_track.

Our system used pandas' `datetime` objects, so I decided the easiest way to comply with existing stuff would be adding this flag. Calling the function without arguments yields the same as before, calling it with `absoluteTime=True` yields pandas' `datetime` objects with absolute timestamps.

This is an edit upon the method I wrote earlier. If you want me to implement the same functionality for the `TdmsFile.as_dataframe` (which, I think can be simplified more than it is right now too), give me a call.

Tested and working
![screenshot from 2015-07-09 13-14-44](https://cloud.githubusercontent.com/assets/1263440/8593925/7e959f8a-263c-11e5-8458-a4efceb0866e.png)
![screenshot from 2015-07-09 13-14-36](https://cloud.githubusercontent.com/assets/1263440/8593926/7e97d23c-263c-11e5-870c-3e6ca1d1396d.png)
