### PR TITLE
Ignore vim .swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.coverage
 /MANIFEST
 *.pyc
+*.swp
 
 # Wercker directories
 _builds


### PR DESCRIPTION
Stupid little patch, but I was checking in .swp files from vim. 