### PR TITLE
Bugfix of absolute datetime values accuracy.

### DIFF
--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -646,7 +646,6 @@ class TdmsObject(object):
         """
 
         try:
-            starttime = self.property('wf_start_time')
             increment = self.property('wf_increment')
             offset = self.property('wf_start_offset')
         except KeyError:
@@ -658,8 +657,14 @@ class TdmsObject(object):
                 offset,
                 offset + (periods - 1) * increment,
                 periods)
+
         if not absoluteTime:
             return relativeTime
+
+        try:
+            starttime = self.property('wf_start_time')
+        except KeyError:
+            raise KeyError("Object does not have start time property available.")
 
         def unit_correction(u):
             if u is 's':

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -626,51 +626,58 @@ class TdmsObject(object):
             raise KeyError(
                 "Object does not have property '%s'" % property_name)
 
-    def time_track(self):
+    def time_track(self, absoluteTime=False, accuracy='ns'):
         """Return an array of time for this channel
 
         This depends on the object having the wf_increment
         and wf_start_offset properties defined.
 
+        For larger timespans, the accuracy setting should be set lower.
+        The default setting is 'ns', which has a timespan of [1678 AD, 2262 AD],
+        for the exact ranges, refer to 
+            http://docs.scipy.org/doc/numpy/reference/arrays.datetime.html
+        section "Datetime Units".
+
+        :param absoluteTime: Whether the returned numpy.array is a datetime64 array
+        :param accuracy: The accuracy of the returned datetime64 array.
         :rtype: NumPy array.
         :raises: KeyError if required properties aren't found
 
         """
 
         try:
+            starttime = self.property('wf_start_time')
             increment = self.property('wf_increment')
             offset = self.property('wf_start_offset')
         except KeyError:
             raise KeyError("Object does not have time properties available.")
 
-        return np.linspace(
+        periods = len(self.data)
+
+        relativeTime = np.linspace(
                 offset,
-                offset + (len(self.data) - 1) * increment,
-                len(self.data))
+                offset + (periods - 1) * increment,
+                periods)
+        if not absoluteTime:
+            return relativeTime
 
-    def pandas_time_track(self):
-        """Return an array of absolute time for this channel
+        def unit_correction(u):
+            if u is 's':
+                return 1e0
+            elif u is 'ms':
+                return 1e3
+            elif u is 'us':
+                return 1e6
+            elif u is 'ns':
+                return 1e9
 
-        This depends on the object having the wf_increment
-        and wf_start_offset properties defined.
-
-        :rtype: pandas Series.
-        :raises: KeyError if required properties aren't found
-
-        """
-
-        import pandas as pd
-
-        try:
-            increment = self.property('wf_increment')
-            offset = pd.to_timedelta(self.property('wf_start_offset'), unit='s')
-            starttime = self.property('wf_start_time')
-        except KeyError:
-            raise KeyError("Object does not have time properties available.")
-
-        return pd.date_range(start=offset + pd.to_datetime(starttime), 
-                periods=len(self.data), 
-                freq=str(int(increment*1e6))+'U')
+        # Because numpy only knows ints as its date datatype, 
+        # convert to accuracy.
+        return (np.datetime64(starttime) 
+                + (relativeTime*unit_correction(accuracy)).astype(
+                    "timedelta64["+accuracy+"]"
+                    )
+                )
 
     def _initialise_data(self, memmap_dir=None):
         """Initialise data array to zeros"""
@@ -719,8 +726,7 @@ class TdmsObject(object):
         import pandas as pd
 
         # When absoluteTime is True, use the wf_start_time as offset for the time_track()
-        time = (self.pandas_time_track() if absoluteTime 
-                else self.time_track())
+        time = self.time_track(absoluteTime)
 
         return pd.DataFrame(self.data,
                 index=time,


### PR DESCRIPTION
The previous implementation of the `absoluteTime` parameter for pandas `to_dataframe` had a bug that would render inaccuracies when working with frequencies of which the reciproque had significant digits < 1e9 seconds, as stated in pullrequest #28.

This could lead to significant errors in the output of larger datasets.

In our example, we had a sampling frequency of 5120 Hertz, which gave an increment of 0.0001953125 seconds, which rounds to 195312 ns. 3072000 records later, that gives an error of about 1700 us.

I fixed this using the numpy.datetime64, the linspace that was already used in time_track. I added two parameters to the time_track() function:

* `absoluteTime` set to `True` will return numpy.datetime64 objects
* `accuracy` defines the accuracy of the numpy.datetime64 object.

The accuracy is something that should be handled by the user. Nanosecond resolution is a good tradeoff between accuracy and possible timespan (approx 292 years) (limited by the 64 bit datetime datatype of numpy).

Now our program has the speed (130Mb/s) and the accuracy back, yihaa!