### PR TITLE
Allow variable length channels when using 'as_dataframe'

### DIFF
--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -309,7 +309,7 @@ class TdmsFile(object):
 
         temp = {}
         for key, value in self.objects.items():
-            temp[key] = value.data
+            temp[key] = pd.Series(data=value.data)
         return pd.DataFrame.from_dict(temp)
 
     def as_dataframe_withtimeindex(self):
@@ -325,7 +325,7 @@ class TdmsFile(object):
         for key, value in self.objects.items():
             if value.has_data:
                 temp[key] = pd.Series(data=value.data, index=value.time_track())
-        return pd.DataFrame.from_dict(temp)        
+        return pd.DataFrame.from_dict(temp)
 
         
 class _TdmsSegment(object):


### PR DESCRIPTION
Hi Adam,

Thanks for the library!

I ran into an issue where a TDMS file has channels of varying length; when using the `as_dataframe` method a `ValueError` exception is thrown as the `ndarray`/`lists` are of variable length.

In order to allow creation of a `DataFrame` where lengths are different we can construct using a `dict` of `pd.Series` - I've included the change here.

I had written a test to show the issue, though I was struggling to get the existing test suite to run on my system - so I've omitted it from this pull request.

Hope this helps!
Peter