### PR TITLE
Added wrapper around np.fromfile to support BytesIO TDMS file streams

### DIFF
--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -92,12 +92,12 @@ else:
     timezone = None
     
     
-def fromfile(file, *args, **kwargs):
+def fromfile(file, dtype, count, *args, **kwargs):
     """ Wrapper around np.fromfile to support BytesIO fake files."""
     if isinstance(file, BytesIO):
-        return np.fromstring(file.getvalue(), *args, **kwargs)
+        return np.fromstring(file.read(count * dtype.itemsize), dtype=dtype, count=count, *args, **kwargs)
     else:
-        return np.fromfile(file, *args, **kwargs)
+        return np.fromfile(file, dtype=dtype, count=count, *args, **kwargs)
 
 
 def read_string(file):


### PR DESCRIPTION
Hi Adam,

Thanks for the great library!

I ran into an issue when trying to read TDMS files using a BytesIO file stream. It appears to be a low-priority issue with `np.fromfile`: https://github.com/numpy/numpy/issues/2230.

So I made a small wrapper for the `np.fromfile` function that checks `isinstance(file, BytesIO)`, and uses `np.fromstring` in this case instead.

I tested to ensure that BytesIO produces the same result as a TDMS file. I don't know if I can share the test however, as I don't think I'm allowed to share the data, and I don't have the ability to write TDMS files to generate a sample.

Adam