### PR TITLE
Allow read/write tdms for any file-like object

### DIFF
--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -43,7 +43,7 @@ def fromfile(file, dtype, count, *args, **kwargs):
 
     try:
         return np.fromfile(file, dtype=dtype, count=count, *args, **kwargs)
-    except (TypeError, UnsupportedOperation):
+    except (TypeError, IOError, UnsupportedOperation):
         return np.frombuffer(
             file.read(count * np.dtype(dtype).itemsize),
             dtype=dtype, count=count, *args, **kwargs)

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -14,7 +14,7 @@ except ImportError:
 from copy import copy
 import numpy as np
 import tempfile
-from io import BytesIO
+from io import UnsupportedOperation
 
 from nptdms.utils import Timer
 from nptdms.common import toc_properties
@@ -39,14 +39,14 @@ except AttributeError:
 
 
 def fromfile(file, dtype, count, *args, **kwargs):
-    """ Wrapper around np.fromfile to support BytesIO fake files."""
+    """Wrapper around np.fromfile to support any file-like object"""
 
-    if isinstance(file, BytesIO):
-        return np.fromstring(
+    try:
+        return np.fromfile(file, dtype=dtype, count=count, *args, **kwargs)
+    except (TypeError, UnsupportedOperation):
+        return np.frombuffer(
             file.read(count * np.dtype(dtype).itemsize),
             dtype=dtype, count=count, *args, **kwargs)
-    else:
-        return np.fromfile(file, dtype=dtype, count=count, *args, **kwargs)
 
 
 def read_property(f):

--- a/nptdms/writer.py
+++ b/nptdms/writer.py
@@ -280,6 +280,6 @@ def to_file(file, array):
 
     try:
         array.tofile(file)
-    except (TypeError, UnsupportedOperation):
+    except (TypeError, IOError, UnsupportedOperation):
         # tostring actually returns bytes
         file.write(array.tostring())

--- a/nptdms/writer.py
+++ b/nptdms/writer.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     OrderedDict = dict
 from datetime import datetime
-from io import BytesIO
+from io import UnsupportedOperation
 import logging
 import numpy as np
 from nptdms.common import toc_properties
@@ -276,10 +276,10 @@ def _map_property_value(value):
 
 
 def to_file(file, array):
-    """Wrapper around ndarray.tofile to support BytesIO
-    """
-    if isinstance(file, BytesIO):
+    """Wrapper around ndarray.tofile to support any file-like object"""
+
+    try:
+        array.tofile(file)
+    except (TypeError, UnsupportedOperation):
         # tostring actually returns bytes
         file.write(array.tostring())
-    else:
-        array.tofile(file)


### PR DESCRIPTION
Specifically, the file-like object only needs to implement:

- `read`

- `write`

- `tell`

- `seek`

- `flush`

- `close`

methods.

Useful for objects like [paramiko SFTPFiles](http://docs.paramiko.org/en/2.1/api/sftp.html#paramiko.sftp_file.SFTPFile)