### PR TITLE
Change DaqMxRawData numpy type to uint16

### DIFF
--- a/nptdms/types.py
+++ b/nptdms/types.py
@@ -215,6 +215,6 @@ class TimeStamp(TdmsType):
                 timedelta(microseconds=micro_seconds))
 
 
-@tds_data_type(0xFFFFFFFF, np.int16)
+@tds_data_type(0xFFFFFFFF, np.uint16)
 class DaqMxRawData(TdmsType):
     size = 2


### PR DESCRIPTION
I ran into an issue with data overflowing to -32767 when it exceeds 32767 before scaling. The TDMS file was created using the NI C API and NI DAQmx 17.1 using a cDAQ9189 chassis and several different modules. I can't seem to find anything in the NI format specification that explicitly states that 'DaqMxRawData' should be unsigned, but after changing the numpy data type my data is consistent with the NI OpenOffice export plugin results. I can provide the TDMS file that caused the issue directly if desired.