### PR TITLE
Use tox and Travis for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+
+matrix:
+  include:
+    - python: "2.6"
+      env: TOXENV=py26
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.3"
+      env: TOXENV=py33
+    - python: "3.4"
+      env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
+
+install:
+  - pip install tox
+
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,22 @@
 language: python
+sudo: false
 
 matrix:
   include:
-    - python: "2.6"
+    - python: 2.6
       env: TOXENV=py26
-    - python: "2.7"
+    - python: 2.7
       env: TOXENV=py27
-    - python: "3.3"
+    - python: 3.3
       env: TOXENV=py33
-    - python: "3.4"
+    - python: 3.4
       env: TOXENV=py34
-    - python: "3.5"
+    - python: 3.5
       env: TOXENV=py35
-    - python: "3.6"
+    - python: 3.6
       env: TOXENV=py36
+    - python: 3.6
+      env: TOXENV=pep8
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,8 @@ matrix:
     - python: 3.6
       env: TOXENV=pep8
   allow_failures:
-    - python: 2.6  # not supported by numpy
-      env: TOXENV=py26
-    - python: 3.3  # not supported by numpy or wheel
-      env: TOXENV=py33
+    - env: TOXENV=py26  # not supported by current numpy
+    - env: TOXENV=py33  # not supported by current numpy or wheel
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ matrix:
       env: TOXENV=py36
     - python: 3.6
       env: TOXENV=pep8
+  allow_failures:
+    - python: 2.6  # not supported by numpy
+      env: TOXENV=py26
+    - python: 3.3  # not supported by numpy or wheel
+      env: TOXENV=py33
 
 install:
   - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ setup(
     'Programming Language :: Python :: 3.2',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Topic :: Scientific/Engineering',
     'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
     'Intended Audience :: Science/Research',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,13 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,py36
+envlist = py{26,27,32,33,34,36},pep8
 
 [testenv]
 deps = nose
 commands =
     nosetests []
+
+[testenv:pep8]
+skip_install = True
+deps = pep8
+commands =
+    pep8 ./nptdms

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py26,py27,py32,py33,py34,py36
+
+[testenv]
+deps = nose
+commands =
+    nosetests []


### PR DESCRIPTION
* Add tox file to support testing in multiple environments
* Add TravisCI file to build in all environments
* Add classifiers for Python 3.5 and 3.6

All builds (except Python 2.6 and 3.3) would pass if the pandas tests are skipped (#96).