### PR TITLE
Fix loading of incomplete segments by cropping data

### DIFF
--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -542,8 +542,18 @@ class _TdmsSegment(object):
         log.debug("all_channel_bytes: %d", all_channel_bytes)
         number_bytes = int(all_channel_bytes * data_objects[0].number_values)
         combined_data = fromfile(f, dtype=np.uint8, count=number_bytes)
-        # Reshape, so that one row is all bytes for all objects
-        combined_data = combined_data.reshape(-1, all_channel_bytes)
+        try:
+            # Reshape, so that one row is all bytes for all objects
+            combined_data = combined_data.reshape(-1, all_channel_bytes)
+        except ValueError:
+            # Probably incomplete segment at the end => try to clip data
+            crop_len = (combined_data.shape[0] // all_channel_bytes)
+            crop_len *= all_channel_bytes
+            log.warning("Cropping data from %d to %d bytes to match segment "
+                        "size derived from channels",
+                        combined_data.shape[0], crop_len)
+            combined_data = combined_data[:crop_len].reshape(-1,
+                                                             all_channel_bytes)
         # Now set arrays for each channel
         data_pos = 0
         for (i, obj) in enumerate(data_objects):


### PR DESCRIPTION
I had some problems with TDMS files which were apparently corrupted during closing which caused an exception during loading (see details below).
This PR fixes the problem by **cropping** the data to fit the computed segment length, as this omits some data from the result a warning is issued.

```WARNING:nptdms.tdms:Data size 130178688 is not a multiple of the chunk size 2000000. Will attempt to read last chunk
INFO:nptdms.tdms:Read metadata: Took 1.999669994006581 ms
INFO:nptdms.tdms:Allocate space: Took 0.7932980848863735 ms
INFO:nptdms.tdms:Read data: Took 559.2725067652964 ms

---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-21-18d4253aefc0> in <module>()
----> 1 data = nptdms.TdmsFile(filenames[0])

d:\code\nptdms-dev\nptdms\tdms.py in __init__(self, file, memmap_dir)
     92             # Is path to a file
     93             with open(file, 'rb') as f:
---> 94                 self._read_segments(f)
     95 
     96     def _read_segments(self, f):

d:\code\nptdms-dev\nptdms\tdms.py in _read_segments(self, f)
    122             # Now actually read all the data
    123             for segment in self.segments:
--> 124                 segment.read_raw_data(f)
    125 
    126     def _path(self, *args):

d:\code\nptdms-dev\nptdms\tdms.py in read_raw_data(self, f)
    510                     set((o.number_values for o in data_objects))) == 1)
    511                 if (all_numpy and same_length):
--> 512                     self._read_interleaved_numpy(f, data_objects)
    513                 else:
    514                     self._read_interleaved(f, data_objects)

d:\code\nptdms-dev\nptdms\tdms.py in _read_interleaved_numpy(self, f, data_objects)
    544         combined_data = fromfile(f, dtype=np.uint8, count=number_bytes)
    545         # Reshape, so that one row is all bytes for all objects
--> 546         combined_data = combined_data.reshape(-1, all_channel_bytes)
    547         # Now set arrays for each channel
    548         data_pos = 0

ValueError: cannot reshape array of size 178688 into shape (40)```