### PR TITLE
Convert Boolean to Python's bool during reading.

### DIFF
--- a/nptdms/types.py
+++ b/nptdms/types.py
@@ -178,6 +178,10 @@ class Boolean(StructType):
     size = 1
     struct_declaration = "b"
 
+    @classmethod
+    def read(cls, file, endianness="<"):
+        return bool(super(Boolean, cls).read(file, endianness))
+
 
 @tds_data_type(0x44, None)
 class TimeStamp(TdmsType):


### PR DESCRIPTION
I use the npTDMS to read and analyse already existing TDMS files. Therefore the correct data type is necessary for the analysis. This patch casts a read boolean value into Python's bool.

PS: You have done a great work to read TDMS files with pure python.