### PR TITLE
Use a child logger for logging

### DIFF
--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -26,25 +26,19 @@ from nptdms import types
 # log level
 log_level = logging.WARNING
 
-# create logger
 log = logging.getLogger(__name__)
 log.setLevel(log_level)
 
-# create console handler and set level to debug
-ch = logging.StreamHandler()
-ch.setLevel(log_level)
+console_handler = logging.StreamHandler()
+console_handler.setLevel(log_level)
 
-# create formatter
 formatter = logging.Formatter('[%(name)s %(levelname)8s] %(message)s')
+console_handler.setFormatter(formatter)
 
-# add formatter to ch
-ch.setFormatter(formatter)
-
-# add ch to logger
-log.addHandler(ch)
+log.addHandler(console_handler)
 
 # To adjust the log level for this module from a script, use eg:
-# logging.getLogger(tdms.__name__).setLevel(logging.DEBUG)
+# logging.getLogger(__name__).setLevel(logging.DEBUG)
 
 # Have to get a reference to the builtin property decorator
 # so we can use it in TdmsObject, which has a property method.

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -23,9 +23,26 @@ from nptdms import scaling
 from nptdms import types
 
 
+# log level
+log_level = logging.WARNING
+
+# create logger
 log = logging.getLogger(__name__)
-logging.basicConfig()
-log.setLevel(logging.WARNING)
+log.setLevel(log_level)
+
+# create console handler and set level to debug
+ch = logging.StreamHandler()
+ch.setLevel(log_level)
+
+# create formatter
+formatter = logging.Formatter('[%(name)s %(levelname)8s] %(message)s')
+
+# add formatter to ch
+ch.setFormatter(formatter)
+
+# add ch to logger
+log.addHandler(ch)
+
 # To adjust the log level for this module from a script, use eg:
 # logging.getLogger(tdms.__name__).setLevel(logging.DEBUG)
 


### PR DESCRIPTION
...to allow better coexistence with logging in other modules.  Patch as discussed in Issue #118 .

run_tests.sh returns 3 warnings, which I think were present before but not being output properly, otherwise this everything seems to have passed:
```
Finished processing dependencies for npTDMS==0.15.1
.........................................[nptdms.tdms  WARNING] Last segment of file has unknown size, not attempting to read it
....[nptdms.tdms  WARNING] Data size 24 is not a multiple of the chunk size 16. Will attempt to read last chunk
.[nptdms.tdms  WARNING] Data size 24 is not a multiple of the chunk size 16. Will attempt to read last chunk
................
----------------------------------------------------------------------
Ran 62 tests in 0.315s

OK
```
