### PR TITLE
Support multiple DAQmx scalers and different DAQmx scaler types

### DIFF
--- a/nptdms/daqmx.py
+++ b/nptdms/daqmx.py
@@ -34,13 +34,14 @@ class DaqMxMetadata(object):
         # size of vector of format changing scalers
         scaler_vector_length = types.Uint32.read(f, endianness)
         log.debug("mxDAQ format scaler vector size '%d'", scaler_vector_length)
-        if scaler_vector_length > 1:
-            log.error("mxDAQ multiple format changing scalers not implemented")
-
         self.scalers = [
             DaqMxScaler(f, endianness)
             for _ in range(scaler_vector_length)]
 
+        # Read raw data widths.
+        # This is an array of widths in bytes, which should be the same
+        # for all channels that have DAQmx data. It's unclear what it means
+        # when there are multiple entries in this array.
         raw_data_widths_length = types.Uint32.read(f, endianness)
         self.raw_data_widths = np.zeros(raw_data_widths_length, dtype=np.int32)
         for width_idx in range(raw_data_widths_length):
@@ -63,21 +64,21 @@ class DaqMxScaler(object):
 
     __slots__ = [
         'scale_id',
-        'scaler_data_type',
-        'scaler_raw_buffer_index',
-        'scaler_raw_byte_offset',
-        'scaler_sample_format_bitmap',
+        'data_type',
+        'raw_buffer_index',
+        'raw_byte_offset',
+        'sample_format_bitmap',
         ]
 
     def __init__(self, open_file, endianness):
-        scaler_data_type_code = types.Uint32.read(open_file, endianness)
-        self.scaler_data_type = (
-            types.tds_data_types[scaler_data_type_code])
+        data_type_code = types.Uint32.read(open_file, endianness)
+        self.data_type = (
+            types.tds_data_types[data_type_code])
 
         # more info for format changing scaler
-        self.scaler_raw_buffer_index = types.Uint32.read(open_file, endianness)
-        self.scaler_raw_byte_offset = types.Uint32.read(open_file, endianness)
-        self.scaler_sample_format_bitmap = types.Uint32.read(
+        self.raw_buffer_index = types.Uint32.read(open_file, endianness)
+        self.raw_byte_offset = types.Uint32.read(open_file, endianness)
+        self.sample_format_bitmap = types.Uint32.read(
             open_file, endianness)
         self.scale_id = types.Uint32.read(open_file, endianness)
 

--- a/nptdms/daqmx.py
+++ b/nptdms/daqmx.py
@@ -72,8 +72,7 @@ class DaqMxScaler(object):
 
     def __init__(self, open_file, endianness):
         data_type_code = types.Uint32.read(open_file, endianness)
-        self.data_type = (
-            types.tds_data_types[data_type_code])
+        self.data_type = DAQMX_TYPES[data_type_code]
 
         # more info for format changing scaler
         self.raw_buffer_index = types.Uint32.read(open_file, endianness)
@@ -89,3 +88,15 @@ class DaqMxScaler(object):
 
         properties_list = ", ".join(properties)
         return "%s(%s)" % (self.__class__.__name__, properties_list)
+
+
+# Type codes for DAQmx scalers don't appear to match
+# the  normal TDMS type codes:
+DAQMX_TYPES = {
+    0: types.Uint8,
+    1: types.Int8,
+    2: types.Uint16,
+    3: types.Int16,
+    4: types.Uint32,
+    5: types.Int32,
+}

--- a/nptdms/scaling.py
+++ b/nptdms/scaling.py
@@ -70,7 +70,7 @@ class MultiScaling(object):
             raise Exception(
                 "Cannot compute data for scale %d" % scaling.input_source)
         elif isinstance(input_scaling, DaqMxScalerScaling):
-            input_data = scaling.scale_daqmx(scaler_data)
+            input_data = input_scaling.scale_daqmx(scaler_data)
         else:
             input_data = self._compute_scaled_data(
                 input_scaling, raw_data, scaler_data)
@@ -100,7 +100,8 @@ def _get_object_scaling(obj):
             scale_type = obj.properties[type_property]
         except KeyError:
             # Scalings are not in properties if they come from DAQmx scalers
-            scalings[scale_indx] = DaqMxScalerScaling(scale_index)
+            scalings[scale_index] = DaqMxScalerScaling(scale_index)
+            continue
         if scale_type == 'Polynomial':
             scalings[scale_index] = _read_polynomial_scaling(obj, scale_index)
         elif scale_type == 'Linear':

--- a/nptdms/scaling.py
+++ b/nptdms/scaling.py
@@ -10,6 +10,8 @@ RAW_DATA_INPUT_SOURCE = 0xFFFFFFFF
 
 
 class LinearScaling(object):
+    """ Linear scaling with slope and intercept
+    """
     def __init__(self, intercept, slope, input_source):
         self.intercept = intercept
         self.slope = slope
@@ -20,6 +22,8 @@ class LinearScaling(object):
 
 
 class PolynomialScaling(object):
+    """ Polynomial scaling with an arbitrary number of coefficients
+    """
     def __init__(self, coefficients, input_source):
         self.coefficients = coefficients
         self.input_source = input_source
@@ -28,35 +32,55 @@ class PolynomialScaling(object):
         return np.polynomial.polynomial.polyval(data, self.coefficients)
 
 
+class DaqMxScalerScaling(object):
+    """ Reads scaler from DAQmx data
+    """
+    def __init__(self, scale_id):
+        self.scale_id = scale_id
+
+    def scale_daqmx(self, scaler_data):
+        return scaler_data[self.scale_id]
+
+
 class MultiScaling(object):
+    """ Computes scaled data from multiple scalings
+    """
     def __init__(self, scalings):
         self.scalings = scalings
 
     def scale(self, data):
         final_scale = self.scalings[-1]
-        return self._compute_scaled_data(final_scale, data)
+        return self._compute_scaled_data(final_scale, data, {})
 
-    def _compute_scaled_data(self, scaling, raw_data):
+    def scale_daqmx(self, scaler_data):
+        final_scale = self.scalings[-1]
+        return self._compute_scaled_data(final_scale, None, scaler_data)
+
+    def _compute_scaled_data(self, scaling, raw_data, scaler_data):
         """ Compute output data from a single scale in the set of all scalings,
             computing any required input scales recursively.
         """
         if scaling.input_source == RAW_DATA_INPUT_SOURCE:
+            if raw_data is None:
+                raise Exception("Invalid scaling input source for DAQmx data")
             return scaling.scale(raw_data)
-        elif scaling.input_source == 0 and self.scalings[0] is None:
-            # Special case where DAQmx data has a single scaler with id 0.
-            # This needs to be fixed to properly handle multiple scalers from
-            # DAQmx data.
-            return scaling.scale(raw_data)
+
+        input_scaling = self.scalings[scaling.input_source]
+        if input_scaling is None:
+            raise Exception(
+                "Cannot compute data for scale %d" % scaling.input_source)
+        elif isinstance(input_scaling, DaqMxScalerScaling):
+            input_data = scaling.scale_daqmx(scaler_data)
         else:
-            input_scaling = self.scalings[scaling.input_source]
-            if input_scaling is None:
-                raise Exception(
-                    "Cannot compute data for scale %d" % scaling.input_source)
-            input_data = self._compute_scaled_data(input_scaling, raw_data)
-            return scaling.scale(input_data)
+            input_data = self._compute_scaled_data(
+                input_scaling, raw_data, scaler_data)
+        return scaling.scale(input_data)
 
 
 def get_scaling(channel):
+    """ Get scaling for a channel from either the channel itself,
+        its group, or the whole TDMS file
+    """
     scalings = (_get_object_scaling(o) for o in _tdms_hierarchy(channel))
     try:
         return next(s for s in scalings if s is not None)
@@ -76,7 +100,7 @@ def _get_object_scaling(obj):
             scale_type = obj.properties[type_property]
         except KeyError:
             # Scalings are not in properties if they come from DAQmx scalers
-            continue
+            scalings[scale_indx] = DaqMxScalerScaling(scale_index)
         if scale_type == 'Polynomial':
             scalings[scale_index] = _read_polynomial_scaling(obj, scale_index)
         elif scale_type == 'Linear':

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -588,7 +588,7 @@ class TdmsObject(object):
         NumPy array containing data if there is data for this object,
         otherwise None.
         """
-        if self._data is None:
+        if self._data is None and not self._scaler_data:
             # self._data is None if data segment is empty
             return np.empty((0, 1))
         if self._data_scaled is None:

--- a/nptdms/types.py
+++ b/nptdms/types.py
@@ -23,13 +23,13 @@ tds_data_types = {}
 numpy_data_types = {}
 
 
-def tds_data_type(enum_value, np_type, default_for_nptype=True):
+def tds_data_type(enum_value, np_type):
     def decorator(cls):
         cls.enum_value = enum_value
         cls.nptype = None if np_type is None else np.dtype(np_type)
         if enum_value is not None:
             tds_data_types[enum_value] = cls
-        if np_type is not None and default_for_nptype:
+        if np_type is not None:
             numpy_data_types[np.dtype(np_type)] = cls
         return cls
     return decorator
@@ -238,6 +238,6 @@ class ComplexDoubleFloat(TdmsType):
     size = 16
 
 
-@tds_data_type(0xFFFFFFFF, np.int16, default_for_nptype=False)
+@tds_data_type(0xFFFFFFFF, None)
 class DaqMxRawData(TdmsType):
-    size = 2
+    pass


### PR DESCRIPTION
For issue #125 and #74. Allow multiple DAQmx scalers per channel, and use them in scalings. Also use the scaler data type from metadata instead of hard-coding Int16 for DAQmx data.

After reviewing the example DAQmx data files I have, it looks like the assumption that the DAQmx scaler data type codes are the same as the normal TDMS data types is incorrect, as the byte widths never match. If instead the type codes are from 0 to 5 for UInt8, Int8, Uint16, Int16, Uint32 and Int32 respectively, then these data types seem to match  the expected scaler data.