### PR TITLE
Implement thermocouple scaling and fix subtract and table scaling

### DIFF
--- a/nptdms/scaling.py
+++ b/nptdms/scaling.py
@@ -279,7 +279,10 @@ class SubtractScaling(object):
     def scale(self, left_data, right_data):
         """ Calculate scaled data
         """
-        return left_data - right_data
+
+        # Subtracting the left operand from the right doesn't make much sense,
+        # but this does match the Excel TDMS plugin behaviour.
+        return right_data - left_data
 
 
 class DaqMxScalerScaling(object):

--- a/nptdms/test/scaling_test.py
+++ b/nptdms/test/scaling_test.py
@@ -123,16 +123,20 @@ class ScalingDataTests(unittest.TestCase):
         tdms_obj._data = np.array([0.5, 1.0, 1.5, 2.5, 3.0, 3.5])
         expected_scaled_data = np.array([2.0, 2.0, 3.0, 6.0, 8.0, 8.0])
 
+        # The scaled values are actually the range of inputs into the scaling,
+        # which are mapped to the pre-scaled values. This makes no sense but
+        # matches the behaviour of the Excel TDMS plugin.
+
         tdms_obj.properties["NI_Number_Of_Scales"] = 1
         tdms_obj.properties["NI_Scale[0]_Scale_Type"] = "Table"
-        tdms_obj.properties["NI_Scale[0]_Table_Pre_Scaled_Values_Size"] = 3
-        tdms_obj.properties["NI_Scale[0]_Table_Pre_Scaled_Values[0]"] = 1.0
-        tdms_obj.properties["NI_Scale[0]_Table_Pre_Scaled_Values[1]"] = 2.0
-        tdms_obj.properties["NI_Scale[0]_Table_Pre_Scaled_Values[2]"] = 3.0
         tdms_obj.properties["NI_Scale[0]_Table_Scaled_Values_Size"] = 3
-        tdms_obj.properties["NI_Scale[0]_Table_Scaled_Values[0]"] = 2.0
-        tdms_obj.properties["NI_Scale[0]_Table_Scaled_Values[1]"] = 4.0
-        tdms_obj.properties["NI_Scale[0]_Table_Scaled_Values[2]"] = 8.0
+        tdms_obj.properties["NI_Scale[0]_Table_Scaled_Values[0]"] = 1.0
+        tdms_obj.properties["NI_Scale[0]_Table_Scaled_Values[1]"] = 2.0
+        tdms_obj.properties["NI_Scale[0]_Table_Scaled_Values[2]"] = 3.0
+        tdms_obj.properties["NI_Scale[0]_Table_Pre_Scaled_Values_Size"] = 3
+        tdms_obj.properties["NI_Scale[0]_Table_Pre_Scaled_Values[0]"] = 2.0
+        tdms_obj.properties["NI_Scale[0]_Table_Pre_Scaled_Values[1]"] = 4.0
+        tdms_obj.properties["NI_Scale[0]_Table_Pre_Scaled_Values[2]"] = 8.0
 
         np.testing.assert_almost_equal(expected_scaled_data, tdms_obj.data)
 

--- a/nptdms/test/scaling_test.py
+++ b/nptdms/test/scaling_test.py
@@ -7,6 +7,15 @@ import numpy as np
 from nptdms import TdmsFile, TdmsObject
 from nptdms.log import log_manager
 
+try:
+    import thermocouples_reference
+except ImportError:
+    thermocouples_reference = None
+try:
+    import scipy
+except ImportError:
+    scipy = None
+
 
 class TestTdmsFile(TdmsFile):
     def __init__(self):
@@ -162,6 +171,55 @@ class ScalingDataTests(unittest.TestCase):
             "NI_Scale[2]_Subtract_Right_Operand_Input_Source"] = 1
 
         np.testing.assert_almost_equal(expected_scaled_data, tdms_obj.data)
+
+    @unittest.skipIf(thermocouples_reference is None,
+                     "thermocouples_reference is not installed")
+    @unittest.skipIf(scipy is None, "scipy is not installed")
+    def test_thermocouple_scaling_voltage_to_temperature(self):
+        """Test thermocouple scaling from a voltage in uV to temperature"""
+
+        tdms_obj = TdmsObject("/'group'/'channel'")
+        tdms_obj._data = np.array([
+            0.0, 10.0, 100.0, 1000.0])
+        expected_scaled_data = np.array([
+            0.0, 0.2534448,  2.5309141, 24.9940185])
+
+        tdms_obj.properties["NI_Number_Of_Scales"] = 1
+        tdms_obj.properties["NI_Scale[0]_Scale_Type"] = "Thermocouple"
+
+        tdms_obj.properties[
+            "NI_Scale[0]_Thermocouple_Thermocouple_Type"] = 10073
+        tdms_obj.properties[
+            "NI_Scale[0]_Thermocouple_Scaling_Direction"] = 0
+        tdms_obj.properties[
+            "NI_Scale[0]_Thermocouple_Input_Source"] = 0xFFFFFFFF
+
+        np.testing.assert_almost_equal(
+            expected_scaled_data, tdms_obj.data, decimal=3)
+
+    @unittest.skipIf(thermocouples_reference is None,
+                     "thermocouples_reference is not installed")
+    def test_thermocouple_scaling_temperature_to_voltage(self):
+        """Test thermocouple scaling from a temperature to voltage in uV"""
+
+        tdms_obj = TdmsObject("/'group'/'channel'")
+        tdms_obj._data = np.array([
+            0.0, 10.0, 50.0, 100.0])
+        expected_scaled_data = np.array([
+            0.0, 396.8619078, 2023.0778862, 4096.2302187])
+
+        tdms_obj.properties["NI_Number_Of_Scales"] = 1
+        tdms_obj.properties["NI_Scale[0]_Scale_Type"] = "Thermocouple"
+
+        tdms_obj.properties[
+            "NI_Scale[0]_Thermocouple_Thermocouple_Type"] = 10073
+        tdms_obj.properties[
+            "NI_Scale[0]_Thermocouple_Scaling_Direction"] = 1
+        tdms_obj.properties[
+            "NI_Scale[0]_Thermocouple_Input_Source"] = 0xFFFFFFFF
+
+        np.testing.assert_almost_equal(
+            expected_scaled_data, tdms_obj.data, decimal=3)
 
     def test_multiple_scalings_applied_in_order(self):
         """Test all scalings applied from multiple scalings

--- a/nptdms/test/scaling_test.py
+++ b/nptdms/test/scaling_test.py
@@ -156,10 +156,12 @@ class ScalingDataTests(unittest.TestCase):
     def test_subtract_scaling(self):
         """ Test scaling that subtracts an input scaling from another"""
 
+        # This behaves the opposite to what you'd expect, the left operand
+        # is subtracted from the right operand.
         tdms_obj = TdmsObject("/'group'/'channel'")
         tdms_obj._scaler_data = {
-            0: np.array([2.0, 4.0, 6.0]),
-            1: np.array([1.0, 2.0, 3.0]),
+            0: np.array([1.0, 2.0, 3.0]),
+            1: np.array([2.0, 4.0, 6.0]),
         }
         expected_scaled_data = np.array([1.0, 2.0, 3.0])
 


### PR DESCRIPTION
With these changes the thermocouple scaling file in #125 mostly works, although there are some values that are out of range for a K type thermocouple that the Excel TDMS plugin still produces a number for, but the thermocouples_reference python package throws a ValueError, so these are converted to NaN.