### PR TITLE
Use numpy datetime64 for TimeStamp properties

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,11 +52,14 @@ Source code lives at https://github.com/adamreeve/npTDMS and any issues can be
 reported at https://github.com/adamreeve/npTDMS/issues.
 Documentation is available at http://nptdms.readthedocs.io.
 
-What Currently Doesn't Work
----------------------------
+Limitations
+-----------
 
 This module doesn't support TDMS files with XML headers or with
 extended floating point data.
+
+TDMS files support timestamps with a resolution of 2^-64 seconds but these
+are read as numpy datetime64 values with microsecond resolution.
 
 Contributors/Thanks
 -------------------

--- a/nptdms/test/types_test.py
+++ b/nptdms/test/types_test.py
@@ -1,0 +1,70 @@
+"""Test type reading and writing"""
+
+from datetime import date, datetime
+import unittest
+import io
+import numpy as np
+
+from nptdms import types
+
+
+class TimeStampTests(unittest.TestCase):
+    def test_timestamp_roundtrip(self):
+        """Test timestamp write from datetime64 then read"""
+
+        self._roundtrip_test('2019-11-08T18:47:00')
+
+    def test_roundtrip_before_epoch(self):
+        """Test reading timestamp before TDMS epoch"""
+
+        self._roundtrip_test('0000-01-01T05:00:00')
+
+    def test_timestamp_with_microseconds(self):
+        """Test timestamp roundtrip with microseconds"""
+
+        self._roundtrip_test('2019-11-08T18:47:00.123456')
+
+    def test_roundtrip_before_epoch_with_microseconds(self):
+        """Test reading timestamp before TDMS epoch with microseconds"""
+
+        self._roundtrip_test('1903-12-31T23:59:59.500')
+
+    def test_timestamp_from_datetime(self):
+        """Test timestamp from built in datetime value"""
+
+        input_datetime = datetime(2019, 11, 8, 18, 47, 0)
+        expected_datetime = np.datetime64('2019-11-08T18:47:00')
+
+        timestamp = types.TimeStamp(input_datetime)
+        data_file = io.BytesIO(timestamp.bytes)
+
+        read_datetime = types.TimeStamp.read(data_file)
+
+        self.assertEqual(expected_datetime, read_datetime)
+
+    def test_timestamp_from_date(self):
+        """Test timestamp from built in date value"""
+
+        input_datetime = date(2019, 11, 8)
+        expected_datetime = np.datetime64('2019-11-08T00:00:00')
+
+        timestamp = types.TimeStamp(input_datetime)
+        data_file = io.BytesIO(timestamp.bytes)
+
+        read_datetime = types.TimeStamp.read(data_file)
+
+        self.assertEqual(expected_datetime, read_datetime)
+
+    def _roundtrip_test(self, time_string):
+        expected_datetime = np.datetime64(time_string)
+
+        timestamp = types.TimeStamp(expected_datetime)
+        data_file = io.BytesIO(timestamp.bytes)
+
+        read_datetime = types.TimeStamp.read(data_file)
+
+        self.assertEqual(expected_datetime, read_datetime)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/nptdms/test/writer/tdms_segment_tests.py
+++ b/nptdms/test/writer/tdms_segment_tests.py
@@ -6,10 +6,6 @@ try:
     from collections import OrderedDict
 except ImportError:
     OrderedDict = dict
-try:
-    import pytz
-except ImportError:
-    pytz = None
 
 from nptdms.writer import TdmsSegment, read_properties_dict
 from nptdms.types import *
@@ -124,8 +120,6 @@ class TDMSTestClass(unittest.TestCase):
 
     def test_properties_are_converted_to_tdms_types(self):
         test_time = datetime.utcnow()
-        if pytz:
-            test_time = test_time.replace(tzinfo=pytz.utc)
 
         properties = {
             "prop1": Int32(1),
@@ -155,12 +149,7 @@ class TDMSTestClass(unittest.TestCase):
 
         tdms_properties = read_properties_dict(properties)
 
-        self.assertEqual(tdms_properties["time_prop"].value.year, 2017)
-        self.assertEqual(tdms_properties["time_prop"].value.month, 11)
-        self.assertEqual(tdms_properties["time_prop"].value.day, 19)
-        self.assertEqual(tdms_properties["time_prop"].value.hour, 0)
-        self.assertEqual(tdms_properties["time_prop"].value.minute, 0)
-        self.assertEqual(tdms_properties["time_prop"].value.second, 0)
+        self.assertEqual(tdms_properties["time_prop"], TimeStamp(test_time))
 
     def test_writing_long_integer_properties(self):
         properties = {


### PR DESCRIPTION
This supports a wider range of values than the built in datetime type and is more appropriate for timestamp data