### PR TITLE
Include test data in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,8 @@ include docs/*.rst
 include docs/conf.py
 include docs/Makefile
 include COPYING COPYING.LESSER
+
+recursive-include nptdms *.*
+include coverage.sh
+include run_tests.sh
+include tox.ini


### PR DESCRIPTION
The tests are included in the sdists, but not the data files needed to actually run them.