### PR TITLE
[WiP] Add lazy loading for contiguous data.

### DIFF
--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -35,12 +35,14 @@ class TdmsFile(object):
         self.segments = []
         self.objects = OrderedDict()
         self.memmap_dir = memmap_dir
+        self.file_path = None
 
         if hasattr(file, "read"):
             # Is a file
             self._read_segments(file)
         else:
             # Is path to a file
+            self.file_path = file
             with open(file, 'rb') as open_file:
                 self._read_segments(open_file)
 

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -124,7 +124,7 @@ class TdmsSegment(object):
         # First four bytes have number of objects in metadata
         num_objects = types.Int32.read(f, self.endianness)
 
-        object_position_offset = 0
+        obj_pos_offset = 0
         for obj in range(num_objects):
             # Read the object path
             object_path = types.String.read(f, self.endianness)
@@ -167,8 +167,8 @@ class TdmsSegment(object):
             segment_obj._read_metadata(f)
             obj._previous_segment_object = segment_obj
 
-            segment_obj.data_position = self.data_position + object_position_offset
-            object_position_offset += segment_obj.data_size
+            segment_obj.data_position = self.data_position + obj_pos_offset
+            obj_pos_offset += segment_obj.data_size
             obj.ordered_segments.append(segment_obj)
 
         self.calculate_chunks()
@@ -610,7 +610,8 @@ class TdmsObject(object):
                 # Object has data but they are not loaded from file yet
                 file_path = self.tdms_file.file_path
                 if file_path is None:
-                    log.warn("Load on demand only supported if TdmsFile is instantiated with a file path.")
+                    log.warning("Load on demand only supported if TdmsFile is"
+                                " instantiated with a file path.")
                     return np.empty((0, 1))
                 with open(self.tdms_file.file_path, 'rb') as f:
                     for obj_segment in self.ordered_segments:


### PR DESCRIPTION
Data is loaded on demand when the option read_metadata_only is used for contiguous files.

Slower, but useful if you need to read only a few objects from your file.
An index of data positions in each segment is stored in TdmsObject.
When data property is accessed, the object has_data is True but _data internal attribute is empty, this is populated opening the file and reading only the requested data.

# Addressed issues
#43 -  lazy loading of raw data

# ToDo:

- Test, Test, Test: for now it has only be tested on a big file (2.5GB) with a single segment
- Chunk-by-chunk reading (I just started to work on tdms internal structure, don't know what a decoder is supposed to do)
- Interleaved data?

# Whish list:

- Subclass np.memmap to fancy load slices of data from a single object?