### PR TITLE
Avoid unnecessary copies of previous segment objects

### DIFF
--- a/nptdms/daqmx.py
+++ b/nptdms/daqmx.py
@@ -91,13 +91,15 @@ class DaqmxSegmentObject(BaseSegmentObject):
         super(DaqmxSegmentObject, self).__init__(path, endianness)
         self.daqmx_metadata = None
 
-    def read_segment_metadata(self, f, raw_data_index):
-        if raw_data_index not in (0x00001269, 0x00001369):
-            raise ValueError("Unexpected raw data index for DAQmx data: 0x%08X" % raw_data_index)
+    def read_raw_data_index(self, f, raw_data_index_header):
+        if raw_data_index_header not in (0x00001269, 0x00001369):
+            raise ValueError(
+                "Unexpected raw data index for DAQmx data: 0x%08X" %
+                raw_data_index_header)
         # This is a DAQmx raw data segment.
         #    0x00001269 for segment containing Format Changing scaler.
         #    0x00001369 for segment containing Digital Line scaler.
-        if raw_data_index == 0x00001369:
+        if raw_data_index_header == 0x00001369:
             # special scaling for DAQ's digital input lines?
             log.warning("DAQmx with Digital Line scaler has not tested")
 

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -199,9 +199,9 @@ class TdmsSegmentObject(BaseSegmentObject):
 
     __slots__ = []
 
-    def read_segment_metadata(self, f, raw_data_index):
+    def read_raw_data_index(self, f, raw_data_index_header):
         # Metadata format is standard (non-DAQmx) TDMS format.
-        # raw_data_index gives the length of the index information.
+        # raw_data_index_header gives the length of the index information.
 
         # Read the data type
         try:


### PR DESCRIPTION
This can be much more memory efficient for some files, eg. the problem file from issue #19 uses 140 MB of memory compared with 640 MB before this change.

Still needs some tidying up and refactoring.