### PR TITLE
Lazy loading of whole channel data

### DIFF
--- a/nptdms/base_segment.py
+++ b/nptdms/base_segment.py
@@ -203,11 +203,11 @@ class BaseSegment(object):
         """Read raw data from a TDMS segment
 
         :returns: A generator of ChannelDataChunk objects with raw channel data for
-            objects in this segment.
+            a single channel in this segment.
         """
 
         if not self.toc_mask & toc_properties['kTocRawData']:
-            yield DataChunk.empty()
+            yield ChannelDataChunk.empty()
 
         f.seek(self.data_position)
 
@@ -253,11 +253,15 @@ class BaseSegment(object):
             for o in self.ordered_objects if o.has_data])
 
     def _read_data_chunk(self, file, data_objects, chunk_index):
+        """ Read data from a chunk for all channels
+        """
         raise NotImplementedError("Data chunk reading must be implemented in base classes")
 
     def _read_channel_data_chunk(self, file, data_objects, chunk_index, channel_path):
+        """ Read data from a chunk for a single channel
+        """
         # In the base case we can read data for all channels
-        # and filter out the requested channel.
+        # and then select only the requested channel.
         # Derived classes can implement more optimised reading.
         data_chunk = self._read_data_chunk(file, data_objects, chunk_index)
         try:
@@ -340,9 +344,8 @@ class ChannelDataChunk(object):
     """Data read for a single channel from a single chunk in a TDMS segment
 
     :ivar raw_data: Raw data in this chunk for a standard TDMS channel.
-        Keys are object paths and values are numpy arrays.
     :ivar daqmx_raw_data: A dictionary of scaler data in this segment for
-        DAQmx raw data. Keys are the scaler id.
+        DAQmx raw data. Keys are the scaler id and values are data arrays.
     """
 
     def __init__(self, data, daqmx_data):

--- a/nptdms/base_segment.py
+++ b/nptdms/base_segment.py
@@ -261,9 +261,9 @@ class BaseSegment(object):
         # Derived classes can implement more optimised reading.
         data_chunk = self._read_data_chunk(file, data_objects, chunk_index)
         try:
-            if data_chunk.raw_data is not None:
+            if data_chunk.raw_data:
                 return ChannelDataChunk.channel_data(data_chunk.raw_data[channel_path])
-            elif data_chunk.daqmx_raw_data is not None:
+            elif data_chunk.daqmx_raw_data:
                 return ChannelDataChunk.scaler_data(data_chunk.daqmx_raw_data[channel_path])
             else:
                 return ChannelDataChunk.empty()

--- a/nptdms/channel_data.py
+++ b/nptdms/channel_data.py
@@ -40,6 +40,7 @@ class ListDataReceiver(object):
         """Initialise new data receiver for a TDMS object
         """
         self.data = []
+        self.scaler_data = {}
 
     def append_data(self, data):
         """Append data from a segment
@@ -63,6 +64,7 @@ class NumpyDataReceiver(object):
         self.path = obj.path
         self.data = _new_numpy_array(
             obj.data_type.nptype, obj.number_values, memmap_dir)
+        self.scaler_data = {}
         self._data_insert_position = 0
         log.debug(
             "Allocated %d sample slots for %s", len(self.data), obj.path)
@@ -93,6 +95,7 @@ class DaqmxDataReceiver(object):
         """
 
         self.path = obj.path
+        self.data = None
         self.scaler_data = {}
         self._scaler_insert_positions = {}
         for scaler_id, scaler_type in obj.scaler_data_types.items():

--- a/nptdms/reader.py
+++ b/nptdms/reader.py
@@ -17,12 +17,29 @@ class TdmsReader(object):
     def __init__(self, tdms_file):
         """ Initialise a new TdmsReader
 
-        :param tdms_file: An opened file object.
+        :param tdms_file: Either the path to the tdms file to read or an already
+            opened file.
         """
-        self._file = tdms_file
         self._segments = None
         self._prev_segment_objects = {}
         self.object_metadata = OrderedDict()
+        self._file_path = None
+
+        if hasattr(tdms_file, "read"):
+            # Is a file
+            self._file = tdms_file
+        else:
+            # Is path to a file
+            self._file = open(tdms_file, 'rb')
+            self._file_path = tdms_file
+
+    def close(self):
+        if self._file_path is not None:
+            # File path was provided so we opened the file and
+            # should close it.
+            self._file.close()
+        # Otherwise always remove reference to the file
+        self._file = None
 
     def read_metadata(self):
         """ Read all metadata and structure information from a TdmsFile

--- a/nptdms/reader.py
+++ b/nptdms/reader.py
@@ -62,6 +62,19 @@ class TdmsReader(object):
             for chunk in segment.read_raw_data(self._file):
                 yield chunk
 
+    def read_raw_data_for_channel(self, channel_path):
+        """ Read raw data for a single channel, chunk by chunk
+
+        :param channel_path: The path of the channel object to read data for
+        :returns: A generator that yields ChannelDataChunk objects
+        """
+        if self._segments is None:
+            raise RuntimeError(
+                "Cannot read data unless metadata has first been read")
+        for segment in self._segments:
+            for chunk in segment.read_raw_data_for_channel(self._file, channel_path):
+                yield chunk
+
     def _update_object_metadata(self, segment):
         """ Update object metadata using the metadata read from a single segment
         """

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -554,10 +554,7 @@ class TdmsObject(object):
     def _scale_data(self, raw_data):
         scale = self._get_scaling()
         if scale is not None:
-            if raw_data.scaler_data:
-                return scale.scale_daqmx(raw_data.scaler_data)
-            else:
-                return scale.scale(raw_data.data)
+            return scale.scale(raw_data)
         elif raw_data.scaler_data:
             raise ValueError("Missing scaling information for DAQmx data")
         else:

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -122,6 +122,8 @@ class TdmsFile(object):
         elif self._file is not None:
             # File was provided, release our reference to it
             self._file = None
+        # Reader can also hold a reference to the file:
+        self._reader = None
 
     def _read_file(self, tdms_file, read_metadata_only):
         self._reader = TdmsReader(tdms_file)

--- a/nptdms/test/test_daqmx.py
+++ b/nptdms/test/test_daqmx.py
@@ -216,11 +216,11 @@ def test_multiple_scalers_with_same_type():
     tdms_data = test_file.load()
     channel = tdms_data.object("Group", "Channel1")
 
-    scaler_0_data = channel.raw_scaler_data(0)
+    scaler_0_data = channel.raw_scaler_data[0]
     assert scaler_0_data.dtype == np.int16
     np.testing.assert_array_equal(scaler_0_data, [1, 2, 3, 4])
 
-    scaler_1_data = channel.raw_scaler_data(1)
+    scaler_1_data = channel.raw_scaler_data[1]
     assert scaler_1_data.dtype == np.int16
     np.testing.assert_array_equal(scaler_1_data, [17, 18, 19, 20])
 
@@ -251,15 +251,15 @@ def test_multiple_scalers_with_different_types():
     tdms_data = test_file.load()
     channel = tdms_data.object("Group", "Channel1")
 
-    scaler_0_data = channel.raw_scaler_data(0)
+    scaler_0_data = channel.raw_scaler_data[0]
     assert scaler_0_data.dtype == np.int8
     np.testing.assert_array_equal(scaler_0_data, [1, 2, 3, 4])
 
-    scaler_1_data = channel.raw_scaler_data(1)
+    scaler_1_data = channel.raw_scaler_data[1]
     assert scaler_1_data.dtype == np.int16
     np.testing.assert_array_equal(scaler_1_data, [17, 18, 19, 20])
 
-    scaler_2_data = channel.raw_scaler_data(2)
+    scaler_2_data = channel.raw_scaler_data[2]
     assert scaler_2_data.dtype == np.int32
     np.testing.assert_array_equal(scaler_2_data, [33, 34, 35, 36])
 
@@ -383,10 +383,10 @@ def test_multiple_raw_data_buffers_with_scalers_split_across_buffers():
     channel_1 = tdms_data.object("Group", "Channel1")
     channel_2 = tdms_data.object("Group", "Channel2")
 
-    scaler_data_1 = channel_1.raw_scaler_data(0)
-    scaler_data_2 = channel_1.raw_scaler_data(1)
-    scaler_data_3 = channel_2.raw_scaler_data(0)
-    scaler_data_4 = channel_2.raw_scaler_data(1)
+    scaler_data_1 = channel_1.raw_scaler_data[0]
+    scaler_data_2 = channel_1.raw_scaler_data[1]
+    scaler_data_3 = channel_2.raw_scaler_data[0]
+    scaler_data_4 = channel_2.raw_scaler_data[1]
 
     for data in [
             scaler_data_1, scaler_data_2, scaler_data_3, scaler_data_4]:

--- a/nptdms/test/test_scaling.py
+++ b/nptdms/test/test_scaling.py
@@ -31,7 +31,7 @@ def test_unsupported_scaling_type():
 def test_linear_scaling():
     """Test linear scaling"""
 
-    data = np.array([1.0, 2.0, 3.0])
+    data = StubTdmsData(np.array([1.0, 2.0, 3.0]))
     expected_scaled_data = np.array([12.0, 14.0, 16.0])
 
     properties = {
@@ -49,7 +49,7 @@ def test_linear_scaling():
 def test_polynomial_scaling():
     """Test polynomial scaling"""
 
-    data = np.array([1.0, 2.0, 3.0])
+    data = StubTdmsData(np.array([1.0, 2.0, 3.0]))
     expected_scaled_data = np.array([16.0, 44.0, 112.0])
 
     properties = {
@@ -69,7 +69,7 @@ def test_polynomial_scaling():
 def test_polynomial_scaling_with_3_coefficients():
     """Test polynomial scaling"""
 
-    data = np.array([1.0, 2.0, 3.0])
+    data = StubTdmsData(np.array([1.0, 2.0, 3.0]))
     expected_scaled_data = np.array([13.0, 20.0, 31.0])
 
     properties = {
@@ -89,7 +89,7 @@ def test_polynomial_scaling_with_3_coefficients():
 def test_rtd_scaling():
     """Test RTD scaling"""
 
-    data = np.array([0.5, 0.6])
+    data = StubTdmsData(np.array([0.5, 0.6]))
     expected_scaled_data = np.array([1256.89628, 1712.83429])
 
     properties = {
@@ -114,7 +114,7 @@ def test_rtd_scaling():
 def test_table_scaling():
     """Test table scaling"""
 
-    data = np.array([0.5, 1.0, 1.5, 2.5, 3.0, 3.5])
+    data = StubTdmsData(np.array([0.5, 1.0, 1.5, 2.5, 3.0, 3.5]))
     expected_scaled_data = np.array([2.0, 2.0, 3.0, 6.0, 8.0, 8.0])
 
     # The scaled values are actually the range of inputs into the scaling,
@@ -142,10 +142,10 @@ def test_table_scaling():
 def test_add_scaling():
     """ Test scaling that adds two input scalings"""
 
-    scaler_data = {
+    scaler_data = StubDaqmxData({
         0: np.array([1.0, 2.0, 3.0]),
         1: np.array([2.0, 4.0, 6.0]),
-    }
+    })
     expected_scaled_data = np.array([3.0, 6.0, 9.0])
 
     properties = {
@@ -155,7 +155,7 @@ def test_add_scaling():
         "NI_Scale[2]_Add_Right_Operand_Input_Source": 1,
     }
     scaling = get_scaling(properties, {}, {})
-    scaled_data = scaling.scale_daqmx(scaler_data)
+    scaled_data = scaling.scale(scaler_data)
 
     np.testing.assert_almost_equal(expected_scaled_data, scaled_data)
 
@@ -165,10 +165,10 @@ def test_subtract_scaling():
 
     # This behaves the opposite to what you'd expect, the left operand
     # is subtracted from the right operand.
-    scaler_data = {
+    scaler_data = StubDaqmxData({
         0: np.array([1.0, 2.0, 3.0]),
         1: np.array([2.0, 4.0, 6.0]),
-    }
+    })
     expected_scaled_data = np.array([1.0, 2.0, 3.0])
 
     properties = {
@@ -178,7 +178,7 @@ def test_subtract_scaling():
         "NI_Scale[2]_Subtract_Right_Operand_Input_Source": 1,
     }
     scaling = get_scaling(properties, {}, {})
-    scaled_data = scaling.scale_daqmx(scaler_data)
+    scaled_data = scaling.scale(scaler_data)
 
     np.testing.assert_almost_equal(expected_scaled_data, scaled_data)
 
@@ -188,10 +188,8 @@ def test_subtract_scaling():
 def test_thermocouple_scaling_voltage_to_temperature():
     """Test thermocouple scaling from a voltage in uV to temperature"""
 
-    data = np.array([
-        0.0, 10.0, 100.0, 1000.0])
-    expected_scaled_data = np.array([
-        0.0, 0.2534448,  2.5309141, 24.9940185])
+    data = StubTdmsData(np.array([0.0, 10.0, 100.0, 1000.0]))
+    expected_scaled_data = np.array([0.0, 0.2534448,  2.5309141, 24.9940185])
 
     properties = {
         "NI_Number_Of_Scales": 1,
@@ -211,8 +209,7 @@ def test_thermocouple_scaling_voltage_to_temperature():
 def test_thermocouple_scaling_temperature_to_voltage():
     """Test thermocouple scaling from a temperature to voltage in uV"""
 
-    data = np.array([
-        0.0, 10.0, 50.0, 100.0])
+    data = StubTdmsData(np.array([0.0, 10.0, 50.0, 100.0]))
     expected_scaled_data = np.array([
         0.0, 396.8619078, 2023.0778862, 4096.2302187])
 
@@ -234,7 +231,7 @@ def test_multiple_scalings_applied_in_order():
     """Test all scalings applied from multiple scalings
     """
 
-    data = np.array([1.0, 2.0, 3.0])
+    data = StubTdmsData(np.array([1.0, 2.0, 3.0]))
     expected_scaled_data = np.array([21.0, 27.0, 33.0])
 
     properties = {
@@ -264,7 +261,7 @@ def test_multiple_scalings_but_all_with_raw_data_input():
        when it has the raw data as the input source
     """
 
-    data = np.array([1.0, 2.0, 3.0])
+    data = StubTdmsData(np.array([1.0, 2.0, 3.0]))
     expected_scaled_data = np.array([6.0, 9.0, 12.0])
 
     properties = {
@@ -291,7 +288,7 @@ def test_multiple_scalings_but_all_with_raw_data_input():
 def test_scaling_from_group():
     """Test linear scaling in a group"""
 
-    data = np.array([1.0, 2.0, 3.0])
+    data = StubTdmsData(np.array([1.0, 2.0, 3.0]))
     expected_scaled_data = np.array([12.0, 14.0, 16.0])
 
     group_properties = {
@@ -309,7 +306,7 @@ def test_scaling_from_group():
 def test_scaling_from_root():
     """Test linear scaling in the root object"""
 
-    data = np.array([1.0, 2.0, 3.0])
+    data = StubTdmsData(np.array([1.0, 2.0, 3.0]))
     expected_scaled_data = np.array([12.0, 14.0, 16.0])
 
     root_properties = {
@@ -322,3 +319,15 @@ def test_scaling_from_root():
     scaled_data = scaling.scale(data)
 
     np.testing.assert_almost_equal(expected_scaled_data, scaled_data)
+
+
+class StubTdmsData(object):
+    def __init__(self, data):
+        self.data = data
+        self.scaler_data = None
+
+
+class StubDaqmxData(object):
+    def __init__(self, scaler_data):
+        self.data = None
+        self.scaler_data = scaler_data

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -1,5 +1,6 @@
 """Test reading of example TDMS files"""
 
+import os
 import numpy as np
 import pytest
 from nptdms import TdmsFile
@@ -30,6 +31,22 @@ def test_lazily_read_channel_data(test_file, expected_data):
                 actual_data = tdms_file.object(group, channel).read_data()
                 assert actual_data.dtype == expected_data.dtype
                 np.testing.assert_almost_equal(actual_data, expected_data)
+
+
+def test_lazily_read_channel_data_with_file_path():
+    """Test reading channel data lazily after initialising with a file path
+    """
+    test_file, expected_data = scenarios.single_segment_with_one_channel().values
+    temp_file = test_file.get_tempfile(delete=False)
+    try:
+        temp_file.file.close()
+        with TdmsFile.open(temp_file.name) as tdms_file:
+            for ((group, channel), expected_data) in expected_data.items():
+                actual_data = tdms_file.object(group, channel).read_data()
+                assert actual_data.dtype == expected_data.dtype
+                np.testing.assert_almost_equal(actual_data, expected_data)
+    finally:
+        os.remove(temp_file.name)
 
 
 def test_read_data_after_close_throws():

--- a/nptdms/test/util.py
+++ b/nptdms/test/util.py
@@ -33,7 +33,7 @@ def segment_objects_metadata(*args):
     return num_objects_hex + "".join(args)
 
 
-def channel_metadata(channel_name, data_type, num_values):
+def channel_metadata(channel_name, data_type, num_values, properties=None):
     return (
         # Length of the object path
         hexlify_value('<I', len(channel_name)) +
@@ -47,9 +47,20 @@ def channel_metadata(channel_name, data_type, num_values):
         "01 00 00 00" +
         # Number of raw data values
         hexlify_value('<Q', num_values) +
-        # Number of properties (0)
-        "00 00 00 00"
+        hex_properties(properties)
     )
+
+
+def hex_properties(properties):
+    if properties is None:
+        properties = {}
+    props_hex = hexlify_value('<I', len(properties))
+    for (prop_name, (prop_type, prop_value)) in properties.items():
+        props_hex += hexlify_value('<I', len(prop_name))
+        props_hex += string_hexlify(prop_name)
+        props_hex += hexlify_value('<I', prop_type)
+        props_hex += prop_value
+    return props_hex
 
 
 def channel_metadata_with_repeated_structure(channel_name):

--- a/nptdms/test/util.py
+++ b/nptdms/test/util.py
@@ -233,15 +233,15 @@ class GeneratedFile(object):
             lead_in = b''
         self._content += lead_in + metadata_bytes + data_bytes
 
-    def get_tempfile(self):
-        named_file = tempfile.NamedTemporaryFile()
+    def get_tempfile(self, **kwargs):
+        named_file = tempfile.NamedTemporaryFile(suffix=".tdms", **kwargs)
         file = named_file.file
         file.write(self._content)
         file.seek(0)
         return named_file
 
     def load(self, *args, **kwargs):
-        with tempfile.NamedTemporaryFile() as named_file:
+        with tempfile.NamedTemporaryFile(suffix=".tdms") as named_file:
             file = named_file.file
             file.write(self._content)
             file.seek(0)

--- a/nptdms/test/util.py
+++ b/nptdms/test/util.py
@@ -233,6 +233,13 @@ class GeneratedFile(object):
             lead_in = b''
         self._content += lead_in + metadata_bytes + data_bytes
 
+    def get_tempfile(self):
+        named_file = tempfile.NamedTemporaryFile()
+        file = named_file.file
+        file.write(self._content)
+        file.seek(0)
+        return named_file
+
     def load(self, *args, **kwargs):
         with tempfile.NamedTemporaryFile() as named_file:
             file = named_file.file


### PR DESCRIPTION
This PR adds support for lazily loading data for a channel after opening a TDMS file, similarly to #144 but with a few differences:
* Adds an explicit `read_data` method to `TdmsObject` to make it obvious this is an expensive operation, and allow extending this later to support loading a subset of the data (#39)
* Supports DAQmx and interleaved data by reading whole chunks and discarding the unneeded data
* Supports segments that have multiple chunks of data without a repeated segment header

This also introduces some static helper methods to make initialising a `TdmsFile` object more straightforward. There is now `TdmsFile.read` to read all data, `TdmsFile.open` to read metadata and keep the file open for reading, and `TdmsFile.read_metadata` to read metadata only.

Fixes #43 