### PR TITLE
Allow reading a subset of channel data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.pyc
 *.swp
 .tox
+.hypothesis
 
 # Wercker directories
 _builds

--- a/nptdms/reader.py
+++ b/nptdms/reader.py
@@ -79,15 +79,19 @@ class TdmsReader(object):
             for chunk in segment.read_raw_data(self._file):
                 yield chunk
 
-    def read_raw_data_for_channel(self, channel_path):
+    def read_raw_data_for_channel(self, channel_path, offset=0, length=None):
         """ Read raw data for a single channel, chunk by chunk
 
         :param channel_path: The path of the channel object to read data for
+        :param offset: Initial position to read data from.
+        :param length: Number of values to attempt to read.
+            Fewer values will be returned if attempting to read beyond the end of the available data.
         :returns: A generator that yields ChannelDataChunk objects
         """
         if self._segments is None:
             raise RuntimeError(
                 "Cannot read data unless metadata has first been read")
+        # TODO: Compute segments + chunks to read, then filter chunk data to requested range
         for segment in self._segments:
             for chunk in segment.read_raw_data_for_channel(self._file, channel_path):
                 yield chunk

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -155,6 +155,7 @@ class TdmsFile(object):
                 num_values = obj.number_values - offset
             else:
                 num_values = min(length, obj.number_values - offset)
+            num_values = max(0, num_values)
             channel_data = get_data_receiver(obj, num_values, self._memmap_dir)
 
         with Timer(log, "Read data"):

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -143,7 +143,7 @@ class TdmsFile(object):
                 if channel_data is not None:
                     obj._set_raw_data(channel_data)
 
-    def _read_channel_data(self, channel_path):
+    def _read_channel_data(self, channel_path, offset=0, length=None):
         if self._reader is None:
             raise RuntimeError(
                 "Cannot read channel data after the underlying TDMS reader is closed")
@@ -553,13 +553,17 @@ class TdmsObject(object):
                     "for a scale_id")
         return self._raw_data.data
 
-    def read_data(self):
+    def read_data(self, offset=0, length=None):
         """ Reads data for this channel from the TDMS file and returns it
 
             This is for use when the TDMS file was opened without immediately reading all data,
             otherwise the data attribute should be used.
+
+            :param offset: Initial position to read data from.
+            :param length: Number of values to attempt to read.
+                Fewer values will be returned if attempting to read beyond the end of the available data.
         """
-        raw_data = self.tdms_file._read_channel_data(self.path)
+        raw_data = self.tdms_file._read_channel_data(self.path, offset, length)
         return self._scale_data(raw_data)
 
     @_property_builtin

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -124,7 +124,7 @@ class TdmsFile(object):
         with Timer(log, "Allocate space"):
             # Allocate space for data
             for (path, obj) in self._objects.items():
-                self._channel_data[path] = get_data_receiver(obj, self._memmap_dir)
+                self._channel_data[path] = get_data_receiver(obj, obj.number_values, self._memmap_dir)
 
         with Timer(log, "Read data"):
             # Now actually read all the data
@@ -151,11 +151,15 @@ class TdmsFile(object):
         obj = self._objects[channel_path]
         with Timer(log, "Allocate space"):
             # Allocate space for data
-            channel_data = get_data_receiver(obj, self._memmap_dir)
+            if length is None:
+                num_values = obj.number_values - offset
+            else:
+                num_values = min(length, obj.number_values - offset)
+            channel_data = get_data_receiver(obj, num_values, self._memmap_dir)
 
         with Timer(log, "Read data"):
             # Now actually read all the data
-            for chunk in self._reader.read_raw_data_for_channel(channel_path):
+            for chunk in self._reader.read_raw_data_for_channel(channel_path, offset, length):
                 if chunk.raw_data is not None:
                     channel_data.append_data(chunk.raw_data)
                 if chunk.daqmx_raw_data is not None:

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -144,6 +144,10 @@ class TdmsFile(object):
                     obj._set_raw_data(channel_data)
 
     def _read_channel_data(self, channel_path, offset=0, length=None):
+        if offset < 0:
+            raise ValueError("offset must be non-negative")
+        if length is not None and length < 0:
+            raise ValueError("length must be non-negative")
         if self._reader is None:
             raise RuntimeError(
                 "Cannot read channel data after the underlying TDMS reader is closed")

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -114,7 +114,7 @@ def test_reading_subset_of_data(offset, length):
 def test_reading_subset_of_data_for_scenario(test_file, expected_data, length, offset):
     """Test reading a subset of a channel's data
     """
-    assume(all(offset <= len(d) for d in expected_data.values()))
+    assume(any(offset <= len(d) for d in expected_data.values()))
     with test_file.get_tempfile() as temp_file:
         with TdmsFile.open(temp_file.file) as tdms_file:
             for ((group, channel), expected_data) in expected_data.items():

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -111,7 +111,7 @@ def test_reading_subset_of_data(offset, length):
 
 @pytest.mark.parametrize("test_file,expected_data", scenarios.get_scenarios())
 @given(offset=strategies.integers(0, 10), length=strategies.integers(0, 10))
-def test_reading_subset_of_data_for_scenario(test_file, expected_data, length, offset):
+def test_reading_subset_of_data_for_scenario(test_file, expected_data, offset, length):
     """Test reading a subset of a channel's data
     """
     assume(any(offset <= len(d) for d in expected_data.values()))

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -122,6 +122,30 @@ def test_reading_subset_of_data_for_scenario(test_file, expected_data, length, o
                 compare_arrays(actual_data, expected_data[offset:offset + length])
 
 
+def test_invalid_offset_throws():
+    """ Exception is thrown when reading a subset of data with an invalid offset
+    """
+    test_file, expected_data = scenarios.single_segment_with_one_channel().values
+    group, channel = list(expected_data.keys())[0]
+    with test_file.get_tempfile() as temp_file:
+        with TdmsFile.open(temp_file.file) as tdms_file:
+            with pytest.raises(ValueError) as exc_info:
+                tdms_file.object(group, channel).read_data(-1, 5)
+            assert "offset must be non-negative" in str(exc_info.value)
+
+
+def test_invalid_length_throws():
+    """ Exception is thrown when reading a subset of data with an invalid length
+    """
+    test_file, expected_data = scenarios.single_segment_with_one_channel().values
+    group, channel = list(expected_data.keys())[0]
+    with test_file.get_tempfile() as temp_file:
+        with TdmsFile.open(temp_file.file) as tdms_file:
+            with pytest.raises(ValueError) as exc_info:
+                tdms_file.object(group, channel).read_data(0, -5)
+            assert "length must be non-negative" in str(exc_info.value)
+
+
 def test_read_data_after_close_throws():
     """ Trying to read after opening and closing without reading data should throw
     """

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -78,6 +78,7 @@ def test_lazily_read_channel_data_with_channel_data_method():
     (0, 10),
     (5, 5),
     (10, 5),
+    (10, 50),
     (6, 7),
     (6, 60),
     (95, 10),

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
   ],
   install_requires = ['numpy'],
   extras_require = {
-      'test': ['pytest>=3.1.0'],
+      'test': ['pytest>=3.1.0', 'hypothesis'],
       'pandas': ['pandas'],
       'hdf': ['h5py>=2.10.0'],
       'thermocouple_scaling': ['thermocouples_reference', 'scipy'],


### PR DESCRIPTION
Fixes #39

This adds new `offset` and `length` parameters to the `read_data` method of `TdmsObject` to allow reading only a subset of a channel's data.