### PR TITLE
TdmsFile API changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,12 +17,13 @@ and is built on top of the `numpy <http://www.numpy.org/>`__ package.
 Data read from a TDMS file is stored in numpy arrays,
 and numpy arrays are also used when writing TDMS file.
 
+TDMS files can contain multiple data channels organised intro groups.
 Typical usage when reading a TDMS file might look like::
 
     from nptdms import TdmsFile
 
-    tdms_file = TdmsFile("path_to_file.tdms")
-    channel = tdms_file.object('Group', 'Channel1')
+    tdms_file = TdmsFile.read("path_to_file.tdms")
+    channel = tdms_file['Group']['Channel1']
     data = channel.data
     time = channel.time_track()
     # do stuff with data

--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -6,13 +6,17 @@ Reading TDMS Files
 
 .. module:: nptdms
 
-.. autoclass:: TdmsFile
+.. autoclass:: TdmsFile()
   :members:
+  :exclude-members: object, objects, group_channels, channel_data
 
-  .. automethod:: __init__
-
-.. autoclass:: TdmsObject
+.. autoclass:: TdmsGroup()
   :members:
+  :exclude-members: group, channel, has_data, property
+
+.. autoclass:: TdmsChannel()
+  :members:
+  :exclude-members: group, channel, has_data, property
 
 Writing TDMS Files
 ------------------

--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -16,7 +16,7 @@ Reading TDMS Files
 
 .. autoclass:: TdmsChannel()
   :members:
-  :exclude-members: group, channel, has_data, property
+  :exclude-members: group, channel, has_data, property, number_values
 
 Writing TDMS Files
 ------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,8 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
+autodoc_member_order = 'bysource'
+
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -26,14 +26,18 @@ Typical usage when reading a TDMS file might look like::
 
     from nptdms import TdmsFile
 
-    tdms_file = TdmsFile("path_to_file.tdms")
+    tdms_file = TdmsFile.read("path_to_file.tdms")
     for group in tdms_file.groups():
-        for channel in tdms_file.group_channels(group):
+        for channel in group.channels():
             # Access dictionary of properties:
             properties = channel.properties
             # Access numpy array of data for channel:
             data = channel.data
             # do stuff with data and properties...
+
+Or to access a channel by group name and channel name directly::
+
+    channel = tdms_file[group_name][channel_name]
 
 And to write a TDMS file::
 

--- a/docs/reading.rst
+++ b/docs/reading.rst
@@ -51,6 +51,39 @@ classes provide access to these properties as a dictionary using their ``propert
     # Get a channel property
     property_value = tdms_file["group name"]["channel name"].properties["channel_property_name"]
 
+Reading large files
+-------------------
+
+TDMS files are often too large to easily fit in memory so npTDMS offers a few ways to deal with this.
+
+If you want to work with all file data as if it was in memory,
+you can pass the ``memmap_dir`` argument when reading a file.
+This will read data into memory mapped numpy arrays on disk,
+and your operating system will then page data in and out of memory as required.
+
+If you have a large file with multiple channels but only need to read them individually,
+you can open a TDMS file for reading without reading all the data immediately
+using the static :py:meth:`~nptdms.TdmsFile.open` method,
+then read channel data as required::
+
+    with TdmsFile.open(tdms_file_path) as tdms_file:
+        channel = tdms_file[group_name][channel_name]
+        channel_data = channel.read_data()
+
+You also have the option to read only a subset of the data.
+For example, to read 200 data points, beginning at offset 1,000::
+
+    with TdmsFile.open(tdms_file_path) as tdms_file:
+        channel = tdms_file[group_name][channel_name]
+        offset = 1000
+        length = 200
+        channel_data = channel.read_data(offset, length)
+
+In cases where you don't need to read the file data and only need to read metadata, you can
+also use the static :py:meth:`~nptdms.TdmsFile.read_metadata` method::
+
+    tdms_file = TdmsFile.read_metadata(tdms_file_path)
+
 Timestamps
 ----------
 

--- a/docs/writing.rst
+++ b/docs/writing.rst
@@ -28,7 +28,8 @@ instance of one of:
 - :py:class:`nptdms.RootObject`. This is the TDMS root object, and there may only be one root object in a segment.
 - :py:class:`nptdms.GroupObject`. This is used to group the channel objects.
 - :py:class:`nptdms.ChannelObject`. An object that contains data.
-- :py:class:`nptdms.TdmsObject`. A TDMS object that was read from a TDMS file using :py:class:`nptdms.TdmsFile`.
+- :py:class:`nptdms.TdmsGroup` or :py:class:`nptdms.TdmsChannel`.
+  A TDMS object that was read from a TDMS file using :py:class:`nptdms.TdmsFile`.
 
 Each of ``RootObject``, ``GroupObject`` and ``ChannelObject``
 may optionally have properties associated with them, which
@@ -67,14 +68,18 @@ is given below::
             group_object,
             channel_object])
 
-You could also read a TDMS file and then re-write it by passing :py:class:`nptdms.TdmsObject`
+You could also read a TDMS file and then re-write it by passing
+:py:class:`nptdms.TdmsGroup` and :py:class:`nptdms.TdmsChannel`
 instances to the ``write_segment`` method. If you want
-to only copy certain objects for example, you could do something like::
+to only copy certain channels for example, you could do something like::
 
-    from nptdms import TdmsFile, TdmsWriter
+    from nptdms import TdmsFile, TdmsWriter, RootObject
 
     original_file = TdmsFile("original_file.tdms")
+    original_groups = original_file.groups()
+    original_channels = [chan for group in original_groups for chan in group.channels()]
 
     with TdmsWriter("copied_file.tdms") as copied_file:
-        objects_to_copy = [obj for obj in original_file.objects.values() if include_object(obj)]
-        copied_file.write_segment(objects_to_copy)
+        root_object = RootObject(original_file.properties)
+        channels_to_copy = [chan for chan in original_channels if include_channel(chan)]
+        copied_file.write_segment([root_object] + original_groups + channels_to_copy)

--- a/nptdms/__init__.py
+++ b/nptdms/__init__.py
@@ -7,5 +7,5 @@ from __future__ import absolute_import
 from .version import __version_info__, __version__
 
 # Export public objects
-from .tdms import TdmsFile, TdmsObject
+from .tdms import TdmsFile
 from .writer import TdmsWriter, RootObject, GroupObject, ChannelObject

--- a/nptdms/__init__.py
+++ b/nptdms/__init__.py
@@ -7,5 +7,5 @@ from __future__ import absolute_import
 from .version import __version_info__, __version__
 
 # Export public objects
-from .tdms import TdmsFile
+from .tdms import TdmsFile, TdmsGroup, TdmsChannel
 from .writer import TdmsWriter, RootObject, GroupObject, ChannelObject

--- a/nptdms/common.py
+++ b/nptdms/common.py
@@ -21,37 +21,86 @@ toc_properties = {
 }
 
 
-def path_components(path):
-    """Convert a path into group and channel name components"""
+class ObjectPath(object):
+    """ Represents the path of an object in a TDMS file
 
-    def yield_components(path):
-        # Iterate over each character and the next character
-        chars = zip_longest(path, path[1:])
-        try:
-            # Iterate over components
+        :ivar group: Group name or None for the root object
+        :ivar channel: Channel name or None for the root object or a group objecct
+    """
+    def __init__(self, *path_components):
+        self.group = None
+        self.channel = None
+        if len(path_components) > 0:
+            self.group = path_components[0]
+        if len(path_components) > 1:
+            self.channel = path_components[1]
+        if len(path_components) > 2:
+            raise ValueError("Object path may only have up to two components")
+        self._path = _components_to_path(self.group, self.channel)
+
+    @property
+    def is_root(self):
+        return self.group is None
+
+    @property
+    def is_group(self):
+        return self.group is not None and self.channel is None
+
+    @staticmethod
+    def from_string(path_string):
+        components = list(_path_components(path_string))
+        return ObjectPath(*components)
+
+    def __str__(self):
+        """ String representation of the object path
+        """
+        return self._path
+
+    def __hash__(self):
+        return hash(self._path)
+
+    def __eq__(self, other):
+        return self._path == str(other)
+
+
+def _path_components(path):
+    """ Generator that yields components within an object path
+    """
+    # Iterate over each character and the next character
+    chars = zip_longest(path, path[1:])
+    try:
+        # Iterate over components
+        while True:
+            char, next_char = next(chars)
+            if char != '/':
+                raise ValueError("Invalid path, expected \"/\"")
+            elif next_char is not None and next_char != "'":
+                raise ValueError("Invalid path, expected \"'\"")
+            else:
+                # Consume "'" or raise StopIteration if at the end
+                next(chars)
+            component = []
+            # Iterate over characters in component name
             while True:
                 char, next_char = next(chars)
-                if char != '/':
-                    raise ValueError("Invalid path, expected \"/\"")
-                elif (next_char is not None and next_char != "'"):
-                    raise ValueError("Invalid path, expected \"'\"")
-                else:
-                    # Consume "'" or raise StopIteration if at the end
+                if char == "'" and next_char == "'":
+                    component += "'"
+                    # Consume second "'"
                     next(chars)
-                component = []
-                # Iterate over characters in component name
-                while True:
-                    char, next_char = next(chars)
-                    if char == "'" and next_char == "'":
-                        component += "'"
-                        # Consume second "'"
-                        next(chars)
-                    elif char == "'":
-                        yield "".join(component)
-                        break
-                    else:
-                        component += char
-        except StopIteration:
-            return
+                elif char == "'":
+                    yield "".join(component)
+                    break
+                else:
+                    component += char
+    except StopIteration:
+        return
 
-    return list(yield_components(path))
+
+def _components_to_path(group, channel):
+    components = []
+    if group is not None:
+        components.append(group)
+    if channel is not None:
+        components.append(channel)
+    return ('/' + '/'.join(
+        ["'" + c.replace("'", "''") + "'" for c in components]))

--- a/nptdms/export/hdf_export.py
+++ b/nptdms/export/hdf_export.py
@@ -1,0 +1,87 @@
+import numpy as np
+from nptdms import types
+
+
+def from_tdms_file(tdms_file, filepath, mode='w', group='/'):
+    """
+    Converts the TDMS file into an HDF5 file
+
+    :param tdms_file: The TDMS file object to convert.
+    :param filepath: The path of the HDF5 file you want to write to.
+    :param mode: The write mode of the HDF5 file. This can be 'w' or 'a'
+    :param group: A group in the HDF5 file that will contain the TDMS data.
+    """
+    import h5py
+
+    # Groups in TDMS are mapped to the first level of the HDF5 hierarchy
+
+    # Channels in TDMS are then mapped to the second level of the HDF5
+    # hierarchy, under the appropriate groups.
+
+    # Properties in TDMS are mapped to attributes in HDF5.
+    # These all exist under the appropriate, channel group etc.
+
+    h5file = h5py.File(filepath, mode)
+
+    container_group = None
+    if group in h5file:
+        container_group = h5file[group]
+    else:
+        container_group = h5file.create_group(group)
+
+    # First write the properties at the root level
+    try:
+        root = tdms_file.object()
+        for property_name, property_value in root.properties.items():
+            container_group.attrs[property_name] = _hdf_attr_value(property_value)
+    except KeyError:
+        # No root object present
+        pass
+
+    # Now iterate through groups and channels,
+    # writing the properties and data
+    for group_name in tdms_file.groups():
+        try:
+            group = tdms_file.object(group_name)
+
+            # Write the group's properties
+            container_group.create_group(group_name)
+            for prop_name, prop_value in group.properties.items():
+                container_group[group_name].attrs[prop_name] = _hdf_attr_value(prop_value)
+
+        except KeyError:
+            # No group object present
+            pass
+
+        # Write properties and data for each channel
+        for channel in tdms_file.group_channels(group_name):
+            channel_key = group_name + '/' + channel.channel
+
+            if channel.data_type is types.String:
+                # Encode as variable length UTF-8 strings
+                channel_data = container_group.create_dataset(
+                    channel_key, (len(channel.data),), dtype=h5py.string_dtype())
+                channel_data[...] = channel.data
+            elif channel.data_type is types.TimeStamp:
+                # Timestamps are represented as fixed length ASCII strings
+                # because HDF doesn't natively support timestamps
+                channel_data = container_group.create_dataset(
+                    channel_key, (len(channel.data),), dtype='S27')
+                string_data = np.datetime_as_string(channel.data, unit='us', timezone='UTC')
+                encoded_data = [s.encode('ascii') for s in string_data]
+                channel_data[...] = encoded_data
+            else:
+                container_group[channel_key] = channel.data
+
+            for prop_name, prop_value in channel.properties.items():
+                container_group[channel_key].attrs[prop_name] = _hdf_attr_value(prop_value)
+
+    return h5file
+
+
+def _hdf_attr_value(value):
+    """ Convert a value into a format suitable for an HDF attribute
+    """
+    if isinstance(value, np.datetime64):
+        return np.string_(np.datetime_as_string(value, unit='us', timezone='UTC'))
+    return value

--- a/nptdms/export/hdf_export.py
+++ b/nptdms/export/hdf_export.py
@@ -30,32 +30,20 @@ def from_tdms_file(tdms_file, filepath, mode='w', group='/'):
         container_group = h5file.create_group(group)
 
     # First write the properties at the root level
-    try:
-        root = tdms_file.object()
-        for property_name, property_value in root.properties.items():
-            container_group.attrs[property_name] = _hdf_attr_value(property_value)
-    except KeyError:
-        # No root object present
-        pass
+    for property_name, property_value in tdms_file.properties.items():
+        container_group.attrs[property_name] = _hdf_attr_value(property_value)
 
     # Now iterate through groups and channels,
     # writing the properties and data
-    for group_name in tdms_file.groups():
-        try:
-            group = tdms_file.object(group_name)
-
-            # Write the group's properties
-            container_group.create_group(group_name)
-            for prop_name, prop_value in group.properties.items():
-                container_group[group_name].attrs[prop_name] = _hdf_attr_value(prop_value)
-
-        except KeyError:
-            # No group object present
-            pass
+    for group in tdms_file.groups():
+        # Write the group's properties
+        container_group.create_group(group.name)
+        for prop_name, prop_value in group.properties.items():
+            container_group[group.name].attrs[prop_name] = _hdf_attr_value(prop_value)
 
         # Write properties and data for each channel
-        for channel in tdms_file.group_channels(group_name):
-            channel_key = group_name + '/' + channel.channel
+        for channel in group.channels():
+            channel_key = group.name + '/' + channel.name
 
             if channel.data_type is types.String:
                 # Encode as variable length UTF-8 strings

--- a/nptdms/export/pandas_export.py
+++ b/nptdms/export/pandas_export.py
@@ -16,10 +16,10 @@ def from_tdms_file(tdms_file, time_index=False, absolute_time=False):
     import pandas as pd
 
     dataframe_dict = OrderedDict()
-    for key, value in tdms_file.objects.items():
-        if value.has_data:
-            index = value.time_track(absolute_time) if time_index else None
-            dataframe_dict[key] = pd.Series(data=value.data, index=index)
+    for group in tdms_file.groups():
+        for channel in group.channels():
+            index = channel.time_track(absolute_time) if time_index else None
+            dataframe_dict[channel.path] = pd.Series(data=channel.data, index=index)
     return pd.DataFrame.from_dict(dataframe_dict)
 
 
@@ -36,8 +36,8 @@ def from_group(group, scaled_data=True):
     import pandas as pd
 
     return pd.DataFrame.from_dict(OrderedDict(
-        (ch.channel, pd.Series(_get_data(ch, scaled_data)))
-        for ch in group.tdms_file.group_channels(group.group)))
+        (ch.name, pd.Series(_get_data(ch, scaled_data)))
+        for ch in group.channels()))
 
 
 def from_channel(channel, absolute_time=False, scaled_data=True):

--- a/nptdms/export/pandas_export.py
+++ b/nptdms/export/pandas_export.py
@@ -1,0 +1,72 @@
+from nptdms.utils import OrderedDict
+
+
+def from_tdms_file(tdms_file, time_index=False, absolute_time=False):
+    """
+    Converts the TDMS file to a DataFrame
+
+    :param tdms_file: TDMS file object to convert.
+    :param time_index: Whether to include a time index for the dataframe.
+    :param absolute_time: If time_index is true, whether the time index
+        values are absolute times or relative to the start time.
+    :return: The full TDMS file data.
+    :rtype: pandas.DataFrame
+    """
+
+    import pandas as pd
+
+    dataframe_dict = OrderedDict()
+    for key, value in tdms_file.objects.items():
+        if value.has_data:
+            index = value.time_track(absolute_time) if time_index else None
+            dataframe_dict[key] = pd.Series(data=value.data, index=index)
+    return pd.DataFrame.from_dict(dataframe_dict)
+
+
+def from_group(group, scaled_data=True):
+    """
+    Converts a TDMS group object to a DataFrame
+
+    :param group: Group object to convert.
+    :param scaled_data: Whether to return scaled or raw data.
+    :return: The TDMS object data.
+    :rtype: pandas.DataFrame
+    """
+
+    import pandas as pd
+
+    return pd.DataFrame.from_dict(OrderedDict(
+        (ch.channel, pd.Series(_get_data(ch, scaled_data)))
+        for ch in group.tdms_file.group_channels(group.group)))
+
+
+def from_channel(channel, absolute_time=False, scaled_data=True):
+    """
+    Converts the TDMS object to a DataFrame
+
+    :param channel: Channel object to convert.
+    :param absolute_time: Whether times should be absolute rather than
+        relative to the start time.
+    :param scaled_data: Whether to return scaled or raw data.
+    :return: The TDMS object data.
+    :rtype: pandas.DataFrame
+    """
+
+    import pandas as pd
+
+    # When absolute_time is True,
+    # use the wf_start_time as offset for the time_track()
+    try:
+        time = channel.time_track(absolute_time)
+    except KeyError:
+        time = None
+
+    return pd.DataFrame(
+        _get_data(channel, scaled_data), index=time, columns=[channel.path])
+
+
+def _get_data(chan, scaled_data):
+    if scaled_data:
+        return chan.data
+    else:
+        return chan.raw_data

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -23,14 +23,18 @@ _property_builtin = property
 
 
 class TdmsFile(object):
-    """Reads and stores data from a TDMS file.
+    """ Reads and stores data from a TDMS file.
+
+    Can be indexed by group name to access a group within the TDMS file, for example::
+        tdms_file = TdmsFile.read(tdms_file_path)
+        group = tdms_file[group_name]
     """
 
     @staticmethod
     def read(file, memmap_dir=None):
         """ Creates a new TdmsFile object and reads all data in the file
 
-        :param file: Either the path to the tdms file to read or an already
+        :param file: Either the path to the TDMS file to read or an already
             opened file.
         :param memmap_dir: The directory to store memory mapped data files in,
             or None to read data into memory. The data files are created
@@ -43,9 +47,9 @@ class TdmsFile(object):
     @staticmethod
     def open(file, memmap_dir=None):
         """ Creates a new TdmsFile object and reads metadata, leaving the file open
-            to allow reading data
+            to allow reading channel data
 
-        :param file: Either the path to the tdms file to read or an already
+        :param file: Either the path to the TDMS file to read or an already
             opened file.
         :param memmap_dir: The directory to store memory mapped data files in,
             or None to read data into memory. The data files are created
@@ -59,15 +63,15 @@ class TdmsFile(object):
     def read_metadata(file):
         """ Creates a new TdmsFile object and only reads the metadata
 
-        :param file: Either the path to the tdms file to read or an already
+        :param file: Either the path to the TDMS file to read or an already
             opened file.
         """
         return TdmsFile(file, read_metadata_only=True)
 
     def __init__(self, file, memmap_dir=None, read_metadata_only=False, keep_open=False):
-        """Initialise a new TDMS file object
+        """Initialise a new TdmsFile object
 
-        :param file: Either the path to the tdms file to read or an already
+        :param file: Either the path to the TDMS file to read or an already
             opened file.
         :param memmap_dir: The directory to store memory mapped data files in,
             or None to read data into memory. The data files are created
@@ -81,8 +85,9 @@ class TdmsFile(object):
         """
 
         self._memmap_dir = memmap_dir
+        self._groups = OrderedDict()
+        self._properties = {}
         self._channel_data = {}
-        self._objects = OrderedDict()
         self._reader = None
 
         reader = TdmsReader(file)
@@ -94,11 +99,45 @@ class TdmsFile(object):
             else:
                 reader.close()
 
-    def __enter__(self):
-        return self
+    def groups(self):
+        """Returns a list of the groups in this file
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
+        :rtype: List of TdmsGroup.
+        """
+
+        return list(self._groups.values())
+
+    @_property_builtin
+    def properties(self):
+        """ Return the properties of this file as a dictionary
+
+        These are the properties associated with the root TDMS object.
+        """
+
+        return self._properties
+
+    def as_dataframe(self, time_index=False, absolute_time=False):
+        """
+        Converts the TDMS file to a DataFrame
+
+        :param time_index: Whether to include a time index for the dataframe.
+        :param absolute_time: If time_index is true, whether the time index
+            values are absolute times or relative to the start time.
+        :return: The full TDMS file data.
+        :rtype: pandas.DataFrame
+        """
+
+        return pandas_export.from_tdms_file(self, time_index, absolute_time)
+
+    def as_hdf(self, filepath, mode='w', group='/'):
+        """
+        Converts the TDMS file into an HDF5 file
+
+        :param filepath: The path of the HDF5 file you want to write to.
+        :param mode: The write mode of the HDF5 file. This can be 'w' or 'a'
+        :param group: A group in the HDF5 file that will contain the TDMS data.
+        """
+        return hdf_export.from_tdms_file(self, filepath, mode, group)
 
     def close(self):
         """ Close the underlying file if it was opened by this TdmsFile
@@ -110,13 +149,57 @@ class TdmsFile(object):
             self._reader.close()
             self._reader = None
 
+    def __getitem__(self, group_name):
+        """ Retrieve a TDMS group from the file by name
+        """
+        try:
+            return self._groups[group_name]
+        except KeyError:
+            raise KeyError("There is no group named '%s' in the TDMS file" % group_name)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
     def _read_file(self, tdms_reader, read_metadata_only):
         tdms_reader.read_metadata()
 
+        # Use object metadata to build group and channel objects
+        group_properties = OrderedDict()
+        group_channels = OrderedDict()
         for (path, obj) in tdms_reader.object_metadata.items():
-            self._objects[path] = TdmsObject(
-                self, path, obj.properties, obj.data_type,
-                obj.scaler_data_types, obj.num_values)
+            components = path_components(path)
+            if len(components) == 0:
+                # Root object provides properties for the whole file
+                self._properties = obj.properties
+            elif len(components) == 1:
+                # Object is a group
+                group_properties[components[0]] = obj.properties
+            else:
+                # Object is a channel
+                channel = TdmsChannel(
+                    self, path, obj.properties, obj.data_type,
+                    obj.scaler_data_types, obj.num_values)
+                if components[0] in group_channels:
+                    group_channels[components[0]].append(channel)
+                else:
+                    group_channels[components[0]] = [channel]
+
+        # Create group objects containing channels and properties
+        for group_name, properties in group_properties.items():
+            try:
+                channels = group_channels[group_name]
+            except KeyError:
+                channels = []
+            group_path = _components_to_path(group_name)
+            self._groups[group_name] = TdmsGroup(group_path, properties, channels)
+        for group_name, channels in group_channels.items():
+            if group_name not in self._groups:
+                # Group with channels but without any corresponding object metadata in the file:
+                group_path = _components_to_path(group_name)
+                self._groups[group_name] = TdmsGroup(group_path, {}, channels)
 
         if not read_metadata_only:
             self._read_data(tdms_reader)
@@ -124,8 +207,10 @@ class TdmsFile(object):
     def _read_data(self, tdms_reader):
         with Timer(log, "Allocate space"):
             # Allocate space for data
-            for (path, obj) in self._objects.items():
-                self._channel_data[path] = get_data_receiver(obj, obj.number_values, self._memmap_dir)
+            for group in self.groups():
+                for channel in group.channels():
+                    self._channel_data[channel.path] = get_data_receiver(
+                        channel, channel.number_values, self._memmap_dir)
 
         with Timer(log, "Read data"):
             # Now actually read all the data
@@ -139,12 +224,13 @@ class TdmsFile(object):
                         channel_data.append_scaler_data(
                             scaler_id, scaler_data)
 
-            for (path, obj) in self._objects.items():
-                channel_data = self._channel_data[path]
-                if channel_data is not None:
-                    obj._set_raw_data(channel_data)
+            for group in self.groups():
+                for channel in group.channels():
+                    channel_data = self._channel_data[channel.path]
+                    if channel_data is not None:
+                        channel._set_raw_data(channel_data)
 
-    def _read_channel_data(self, channel_path, offset=0, length=None):
+    def _read_channel_data(self, channel, offset=0, length=None):
         if offset < 0:
             raise ValueError("offset must be non-negative")
         if length is not None and length < 0:
@@ -153,19 +239,18 @@ class TdmsFile(object):
             raise RuntimeError(
                 "Cannot read channel data after the underlying TDMS reader is closed")
 
-        obj = self._objects[channel_path]
         with Timer(log, "Allocate space"):
             # Allocate space for data
             if length is None:
-                num_values = obj.number_values - offset
+                num_values = channel.number_values - offset
             else:
-                num_values = min(length, obj.number_values - offset)
+                num_values = min(length, channel.number_values - offset)
             num_values = max(0, num_values)
-            channel_data = get_data_receiver(obj, num_values, self._memmap_dir)
+            channel_data = get_data_receiver(channel, num_values, self._memmap_dir)
 
         with Timer(log, "Read data"):
             # Now actually read all the data
-            for chunk in self._reader.read_raw_data_for_channel(channel_path, offset, length):
+            for chunk in self._reader.read_raw_data_for_channel(channel.path, offset, length):
                 if chunk.raw_data is not None:
                     channel_data.append_data(chunk.raw_data)
                 if chunk.daqmx_raw_data is not None:
@@ -197,46 +282,21 @@ class TdmsFile(object):
 
         object_path = _components_to_path(*path)
         try:
-            return self._objects[object_path]
+            return self.objects[object_path]
         except KeyError:
             raise KeyError("Invalid object path: %s" % object_path)
-
-    def groups(self):
-        """Return the names of groups in the file
-
-        Note that there is not necessarily a TDMS object associated with
-        each group name.
-
-        :rtype: List of strings.
-
-        """
-
-        # Split paths into components and take the first (group) component.
-        object_paths = (
-            path_components(path)
-            for path in self._objects)
-        group_names = (path[0] for path in object_paths if len(path) > 0)
-
-        # Use an ordered dict as an ordered set to find unique
-        # groups in order.
-        groups_set = OrderedDict()
-        for group in group_names:
-            groups_set[group] = None
-        return list(groups_set)
 
     def group_channels(self, group):
         """Returns a list of channel objects for the given group
 
-        :param group: Name of the group to get channels for.
+        :param group: Group or name of the group to get channels for.
         :rtype: List of :class:`TdmsObject` objects.
-
         """
 
-        path = _components_to_path(group)
-        return [
-            self._objects[p]
-            for p in self._objects
-            if p.startswith(path + '/')]
+        if isinstance(group, TdmsGroup):
+            return group.channels()
+
+        return self._groups[group].channels()
 
     def channel_data(self, group, channel):
         """Get the data for a channel
@@ -245,86 +305,85 @@ class TdmsFile(object):
         :param channel: The name of the channel to get data for.
         :returns: The channel data.
         :rtype: NumPy array.
-
         """
 
         if self._reader is None:
             # Data should have already been loaded
-            return self.object(group, channel).data
+            return self[group][channel].data
         else:
             # Data must be lazily loaded
-            return self.object(group, channel).read_data()
-
-    @_property_builtin
-    def properties(self):
-        """ Return the properties of this file as a dictionary
-
-        These are the properties associated with the root TDMS object.
-        """
-
-        try:
-            obj = self.object()
-            return obj.properties
-        except KeyError:
-            return {}
+            return self[group][channel].read_data()
 
     @_property_builtin
     def objects(self):
         """ A dictionary of objects in the TDMS file, where the keys are the object paths.
         """
-        return self._objects
+        objects = OrderedDict()
+        root_path = _components_to_path()
+        objects[root_path] = RootObject(self._properties)
 
-    def as_dataframe(self, time_index=False, absolute_time=False):
+        for group in self.groups():
+            objects[group.path] = group
+            for channel in group.channels():
+                objects[channel.path] = channel
+
+        return objects
+
+
+class TdmsGroup(object):
+    """ Represents a group of channels in a TDMS file.
+
+    Can be indexed by channel name to access a channel in this group, for example::
+        channel = group[channel_name]
+
+    :ivar path: The TDMS object path.
+    :ivar properties: Dictionary of TDMS properties defined for this group.
+    """
+
+    def __init__(self, path, properties, channels):
+        self.path = path
+        self.properties = properties
+        self._channels = {c.name: c for c in channels}
+
+    def __repr__(self):
+        return "<TdmsGroup with path %s>" % self.path
+
+    @_property_builtin
+    def name(self):
+        """ The name of this group
         """
-        Converts the TDMS file to a DataFrame
+        path = path_components(self.path)
+        return path[0]
 
-        :param time_index: Whether to include a time index for the dataframe.
-        :param absolute_time: If time_index is true, whether the time index
-            values are absolute times or relative to the start time.
-        :return: The full TDMS file data.
+    def channels(self):
+        """ The list of channels in this group
+
+        :rtype: A list of TdmsChannel
+        """
+        return list(self._channels.values())
+
+    def as_dataframe(self, absolute_time=False, scaled_data=True):
+        """
+        Converts the TDMS group to a DataFrame
+
+        :param absolute_time: Whether times should be absolute rather than
+            relative to the start time.
+        :param scaled_data: Whether to return scaled or raw data.
+        :return: The TDMS object data.
         :rtype: pandas.DataFrame
         """
 
-        return pandas_export.from_tdms_file(self, time_index, absolute_time)
+        return pandas_export.from_group(self, scaled_data)
 
-    def as_hdf(self, filepath, mode='w', group='/'):
+    def __getitem__(self, channel_name):
+        """ Retrieve a TDMS channel from this group by name
         """
-        Converts the TDMS file into an HDF5 file
-
-        :param filepath: The path of the HDF5 file you want to write to.
-        :param mode: The write mode of the HDF5 file. This can be 'w' or 'a'
-        :param group: A group in the HDF5 file that will contain the TDMS data.
-        """
-        return hdf_export.from_tdms_file(self, filepath, mode, group)
-
-
-class TdmsObject(object):
-    """Represents an object in a TDMS file.
-
-    :ivar path: The TDMS object path.
-    :ivar properties: Dictionary of TDMS properties defined for this object,
-                      for example the start time and time increment for
-                      waveforms.
-    :ivar has_data: Boolean, true if there is data associated with the object.
-
-    """
-
-    def __init__(
-            self, tdms_file, path, properties, data_type=None,
-            scaler_data_types=None, number_values=0):
-        self.tdms_file = tdms_file
-        self.path = path
-        self.properties = properties
-        self.number_values = number_values
-        self.data_type = data_type
-        self.scaler_data_types = scaler_data_types
-        self.has_data = number_values > 0
-
-        self._raw_data = None
-        self._data_scaled = None
-
-    def __repr__(self):
-        return "<TdmsObject with path %s>" % self.path
+        try:
+            return self._channels[channel_name]
+        except KeyError:
+            raise KeyError(
+                "There is no channel named '%s' in group '%s' of the TDMS file" %
+                (channel_name, self.name))
 
     def property(self, property_name):
         """Returns the value of a TDMS property
@@ -332,7 +391,223 @@ class TdmsObject(object):
         :param property_name: The name of the property to get.
         :returns: The value of the requested property.
         :raises: KeyError if the property isn't found.
+        """
 
+        try:
+            return self.properties[property_name]
+        except KeyError:
+            raise KeyError(
+                "Object does not have property '%s'" % property_name)
+
+    @_property_builtin
+    def group(self):
+        """ Returns the name of the group for this object,
+            or None if it is the root object.
+        """
+        path = path_components(self.path)
+        if len(path) > 0:
+            return path[0]
+        return None
+
+    @_property_builtin
+    def channel(self):
+        """ Returns the name of the channel for this object,
+            or None if it is a group or the root object.
+        """
+        return None
+
+    @_property_builtin
+    def has_data(self):
+        return False
+
+
+class TdmsChannel(object):
+    """Represents a channel in a TDMS file.
+
+    :ivar path: The TDMS object path.
+    :ivar properties: Dictionary of TDMS properties defined for this channel,
+                      for example the start time and time increment for waveforms.
+    """
+
+    def __init__(
+            self, tdms_file, path, properties, data_type=None,
+            scaler_data_types=None, number_values=0):
+        self._tdms_file = tdms_file
+        self.path = path
+        self.properties = properties
+        self.number_values = number_values
+        self.data_type = data_type
+        self.scaler_data_types = scaler_data_types
+
+        self._raw_data = None
+        self._data_scaled = None
+
+    def __repr__(self):
+        return "<TdmsChannel with path %s>" % self.path
+
+    @_property_builtin
+    def name(self):
+        """ The name of this channel
+        """
+        path = path_components(self.path)
+        return path[1]
+
+    def read_data(self, offset=0, length=None):
+        """ Reads data for this channel from the TDMS file and returns it
+
+            This is for use when the TDMS file was opened without immediately reading all data,
+            otherwise the data attribute should be used.
+
+            :param offset: Initial position to read data from.
+            :param length: Number of values to attempt to read.
+                Fewer values will be returned if attempting to read beyond the end of the available data.
+        """
+        raw_data = self._tdms_file._read_channel_data(self, offset, length)
+        return self._scale_data(raw_data)
+
+    def time_track(self, absolute_time=False, accuracy='ns'):
+        """Return an array of time or the independent variable for this channel
+
+        This depends on the object having the wf_increment
+        and wf_start_offset properties defined.
+        Note that wf_start_offset is usually zero for time-series data.
+        If you have time-series data channels with different start times,
+        you should use the absolute time or calculate the time offsets using
+        the wf_start_time property.
+
+        For larger timespans, the accuracy setting should be set lower.
+        The default setting is 'ns', which has a timespan of
+        [1678 AD, 2262 AD]. For the exact ranges, refer to
+        http://docs.scipy.org/doc/numpy/reference/arrays.datetime.html
+        section "Datetime Units".
+
+        :param absolute_time: Whether the returned time values are absolute
+            times rather than relative to the start time. If true, the
+            wf_start_time property must be set.
+        :param accuracy: The accuracy of the returned datetime64 array.
+        :rtype: NumPy array.
+        :raises: KeyError if required properties aren't found
+
+        """
+
+        try:
+            increment = self.properties['wf_increment']
+            offset = self.properties['wf_start_offset']
+        except KeyError:
+            raise KeyError("Object does not have time properties available.")
+
+        relative_time = np.linspace(
+            offset,
+            offset + (self.number_values - 1) * increment,
+            self.number_values)
+
+        if not absolute_time:
+            return relative_time
+
+        try:
+            start_time = self.properties['wf_start_time']
+        except KeyError:
+            raise KeyError(
+                "Object does not have start time property available.")
+
+        try:
+            unit_correction = {
+                's': 1e0,
+                'ms': 1e3,
+                'us': 1e6,
+                'ns': 1e9,
+            }[accuracy]
+        except KeyError:
+            raise KeyError("Invalid accuracy: {0}".format(accuracy))
+
+        # Because numpy only knows ints as its date datatype,
+        # convert to accuracy.
+        time_type = "timedelta64[{0}]".format(accuracy)
+        return (np.datetime64(start_time) +
+                (relative_time * unit_correction).astype(time_type))
+
+    def as_dataframe(self, absolute_time=False, scaled_data=True):
+        """
+        Converts the TDMS channel to a DataFrame
+
+        :param absolute_time: Whether times should be absolute rather than
+            relative to the start time.
+        :param scaled_data: Whether to return scaled or raw data.
+        :return: The TDMS object data.
+        :rtype: pandas.DataFrame
+        """
+
+        return pandas_export.from_channel(self, absolute_time, scaled_data)
+
+    @_property_builtin
+    def data(self):
+        """
+        NumPy array containing the data for this channel
+        """
+        if self.number_values > 0 and self._raw_data is None:
+            raise RuntimeError("Channel data has not been read")
+
+        if self._raw_data is None:
+            return np.empty((0, 1))
+        if self._data_scaled is None:
+            self._data_scaled = self._scale_data(self._raw_data)
+        return self._data_scaled
+
+    @_property_builtin
+    def raw_data(self):
+        """
+        The raw, unscaled data array.
+        For unscaled objects this is the same as the data property.
+        """
+        if self.number_values > 0 and self._raw_data is None:
+            raise RuntimeError("Channel data has not been read")
+
+        if self._raw_data is None:
+            return np.empty((0, 1))
+        if self._raw_data.scaler_data:
+            if len(self._raw_data.scaler_data) == 1:
+                return next(v for v in self._raw_data.scaler_data.values())
+            else:
+                raise Exception(
+                    "This object has data for multiple DAQmx scalers, "
+                    "use the raw_scaler_data property to get raw data "
+                    "for a scale_id")
+        return self._raw_data.data
+
+    @_property_builtin
+    def raw_scaler_data(self):
+        """ Raw DAQmx scaler data as a dictionary mapping from scale id to raw data arrays
+        """
+        if self.number_values > 0 and self._raw_data is None:
+            raise RuntimeError("Channel data has not been read")
+
+        return self._raw_data.scaler_data
+
+    def _scale_data(self, raw_data):
+        scale = self._get_scaling()
+        if scale is not None:
+            return scale.scale(raw_data)
+        elif raw_data.scaler_data:
+            raise ValueError("Missing scaling information for DAQmx data")
+        else:
+            return raw_data.data
+
+    def _get_scaling(self):
+        path = path_components(self.path)
+        group_properties = self._tdms_file[path[0]].properties
+        file_properties = self._tdms_file.properties
+        return scaling.get_scaling(
+            self.properties, group_properties, file_properties)
+
+    def _set_raw_data(self, data):
+        self._raw_data = data
+
+    def property(self, property_name):
+        """Returns the value of a TDMS property
+
+        :param property_name: The name of the property to get.
+        :returns: The value of the requested property.
+        :raises: KeyError if the property isn't found.
         """
 
         try:
@@ -361,166 +636,33 @@ class TdmsObject(object):
             return path[1]
         return None
 
-    def time_track(self, absolute_time=False, accuracy='ns'):
-        """Return an array of time or the independent variable for this channel
+    @_property_builtin
+    def has_data(self):
+        return True
 
-        This depends on the object having the wf_increment
-        and wf_start_offset properties defined.
-        Note that wf_start_offset is usually zero for time-series data.
-        If you have time-series data channels with different start times,
-        you should use the absolute time or calculate the time offsets using
-        the wf_start_time property.
 
-        For larger timespans, the accuracy setting should be set lower.
-        The default setting is 'ns', which has a timespan of
-        [1678 AD, 2262 AD]. For the exact ranges, refer to
-        http://docs.scipy.org/doc/numpy/reference/arrays.datetime.html
-        section "Datetime Units".
+class RootObject(object):
+    def __init__(self, properties):
+        self.properties = properties
 
-        :param absolute_time: Whether the returned time values are absolute
-            times rather than relative to the start time. If true, the
-            wf_start_time property must be set.
-        :param accuracy: The accuracy of the returned datetime64 array.
-        :rtype: NumPy array.
-        :raises: KeyError if required properties aren't found
-
-        """
-
+    def property(self, property_name):
         try:
-            increment = self.property('wf_increment')
-            offset = self.property('wf_start_offset')
-        except KeyError:
-            raise KeyError("Object does not have time properties available.")
-
-        relative_time = np.linspace(
-            offset,
-            offset + (self.number_values - 1) * increment,
-            self.number_values)
-
-        if not absolute_time:
-            return relative_time
-
-        try:
-            start_time = self.property('wf_start_time')
+            return self.properties[property_name]
         except KeyError:
             raise KeyError(
-                "Object does not have start time property available.")
-
-        try:
-            unit_correction = {
-                's': 1e0,
-                'ms': 1e3,
-                'us': 1e6,
-                'ns': 1e9,
-            }[accuracy]
-        except KeyError:
-            raise KeyError("Invalid accuracy: {0}".format(accuracy))
-
-        # Because numpy only knows ints as its date datatype,
-        # convert to accuracy.
-        time_type = "timedelta64[{0}]".format(accuracy)
-        return (np.datetime64(start_time) +
-                (relative_time * unit_correction).astype(time_type))
-
-    def as_dataframe(self, absolute_time=False, scaled_data=True):
-        """
-        Converts the TDMS object to a DataFrame
-
-        :param absolute_time: Whether times should be absolute rather than
-            relative to the start time.
-        :param scaled_data: Whether to return scaled or raw data.
-        :return: The TDMS object data.
-        :rtype: pandas.DataFrame
-        """
-
-        if self.channel is None:
-            return pandas_export.from_group(self, scaled_data)
-        else:
-            return pandas_export.from_channel(self, absolute_time, scaled_data)
+                "Object does not have property '%s'" % property_name)
 
     @_property_builtin
-    def data(self):
-        """
-        NumPy array containing data if there is data for this object,
-        otherwise None.
-        """
-        if self.has_data and self._raw_data is None:
-            raise RuntimeError("Channel data has not been read")
-
-        if self._raw_data is None:
-            return np.empty((0, 1))
-        if self._data_scaled is None:
-            self._data_scaled = self._scale_data(self._raw_data)
-        return self._data_scaled
+    def group(self):
+        return None
 
     @_property_builtin
-    def raw_data(self):
-        """
-        The raw, unscaled data array.
-        For unscaled objects this is the same as the data property.
-        """
-        if self.has_data and self._raw_data is None:
-            raise RuntimeError("Channel data has not been read")
-
-        if self._raw_data is None:
-            return np.empty((0, 1))
-        if self._raw_data.scaler_data:
-            if len(self._raw_data.scaler_data) == 1:
-                return next(v for v in self._raw_data.scaler_data.values())
-            else:
-                raise Exception(
-                    "This object has data for multiple DAQmx scalers, "
-                    "use the raw_scaler_data property to get raw data "
-                    "for a scale_id")
-        return self._raw_data.data
-
-    def read_data(self, offset=0, length=None):
-        """ Reads data for this channel from the TDMS file and returns it
-
-            This is for use when the TDMS file was opened without immediately reading all data,
-            otherwise the data attribute should be used.
-
-            :param offset: Initial position to read data from.
-            :param length: Number of values to attempt to read.
-                Fewer values will be returned if attempting to read beyond the end of the available data.
-        """
-        raw_data = self.tdms_file._read_channel_data(self.path, offset, length)
-        return self._scale_data(raw_data)
+    def channel(self):
+        return None
 
     @_property_builtin
-    def raw_scaler_data(self):
-        """ Raw DAQmx scaler data as a dictionary mapping from scale id to raw data arrays
-        """
-        if self.has_data and self._raw_data is None:
-            raise RuntimeError("Channel data has not been read")
-
-        return self._raw_data.scaler_data
-
-    def _scale_data(self, raw_data):
-        scale = self._get_scaling()
-        if scale is not None:
-            return scale.scale(raw_data)
-        elif raw_data.scaler_data:
-            raise ValueError("Missing scaling information for DAQmx data")
-        else:
-            return raw_data.data
-
-    def _get_scaling(self):
-        try:
-            group = self.tdms_file.object(self.group)
-        except KeyError:
-            group = None
-        group_properties = {} if group is None else group.properties
-        try:
-            root_obj = self.tdms_file.object()
-        except KeyError:
-            root_obj = None
-        file_properties = {} if root_obj is None else root_obj.properties
-        return scaling.get_scaling(
-            self.properties, group_properties, file_properties)
-
-    def _set_raw_data(self, data):
-        self._raw_data = data
+    def has_data(self):
+        return False
 
 
 def _components_to_path(*args):

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -260,7 +260,7 @@ class TdmsFile(object):
         return channel_data
 
     def object(self, *path):
-        """Get a TDMS object from the file
+        """(Deprecated) Get a TDMS object from the file
 
         :param path: The object group and channel. Providing no channel
             returns a group object, and providing no channel or group
@@ -280,6 +280,11 @@ class TdmsFile(object):
             object("group_name", "channel_name")
         """
 
+        _deprecated("TdmsFile.object",
+                    "Use TdmsFile.properties to access properties of the root object, " +
+                    "TdmsFile[group_name] to access a group object and " +
+                    "TdmsFile[group_name][channel_name] to access a channel object.")
+
         object_path = ObjectPath(*path)
         try:
             return self.objects[str(object_path)]
@@ -287,11 +292,13 @@ class TdmsFile(object):
             raise KeyError("Invalid object path: %s" % object_path)
 
     def group_channels(self, group):
-        """Returns a list of channel objects for the given group
+        """(Deprecated) Returns a list of channel objects for the given group
 
         :param group: Group or name of the group to get channels for.
         :rtype: List of :class:`TdmsObject` objects.
         """
+
+        _deprecated("TdmsFile.group_channels", "Use TdmsFile[group_name].channels().")
 
         if isinstance(group, TdmsGroup):
             return group.channels()
@@ -299,13 +306,15 @@ class TdmsFile(object):
         return self._groups[group].channels()
 
     def channel_data(self, group, channel):
-        """Get the data for a channel
+        """(Deprecated)  Get the data for a channel
 
         :param group: The name of the group the channel is in.
         :param channel: The name of the channel to get data for.
         :returns: The channel data.
         :rtype: NumPy array.
         """
+
+        _deprecated("TdmsFile.channel_data", "Use TdmsFile[group_name][channel_name].data.")
 
         if self._reader is None:
             # Data should have already been loaded
@@ -316,8 +325,12 @@ class TdmsFile(object):
 
     @_property_builtin
     def objects(self):
-        """ A dictionary of objects in the TDMS file, where the keys are the object paths.
+        """ (Deprecated) A dictionary of objects in the TDMS file, where the keys are the object paths.
         """
+
+        _deprecated("TdmsFile.objects", "Use TdmsFile.groups() to access all groups in the file, " +
+                    "and group.channels() to access all channels in a group.")
+
         objects = OrderedDict()
         root_path = ObjectPath()
         objects[str(root_path)] = RootObject(self._properties)
@@ -391,12 +404,14 @@ class TdmsGroup(object):
                 (channel_name, self.name))
 
     def property(self, property_name):
-        """Returns the value of a TDMS property
+        """(Deprecated) Returns the value of a TDMS property
 
         :param property_name: The name of the property to get.
         :returns: The value of the requested property.
         :raises: KeyError if the property isn't found.
         """
+
+        _deprecated("TdmsGroup.property", "Use TdmsGroup.properties[property_name].")
 
         try:
             return self.properties[property_name]
@@ -406,20 +421,24 @@ class TdmsGroup(object):
 
     @_property_builtin
     def group(self):
-        """ Returns the name of the group for this object,
+        """ (Deprecated) Returns the name of the group for this object,
             or None if it is the root object.
         """
+        _deprecated("TdmsGroup.group", "Use TdmsGroup.name.")
         return self._path.group
 
     @_property_builtin
     def channel(self):
-        """ Returns the name of the channel for this object,
+        """ (Deprecated) Returns the name of the channel for this object,
             or None if it is a group or the root object.
         """
+        _deprecated("TdmsGroup.channel", "This always returns None.")
         return None
 
     @_property_builtin
     def has_data(self):
+        """(Deprecated)"""
+        _deprecated("TdmsGroup.has_data", "This always returns False.")
         return False
 
 
@@ -613,12 +632,13 @@ class TdmsChannel(object):
         self._raw_data = data
 
     def property(self, property_name):
-        """Returns the value of a TDMS property
+        """(Deprecated) Returns the value of a TDMS property
 
         :param property_name: The name of the property to get.
         :returns: The value of the requested property.
         :raises: KeyError if the property isn't found.
         """
+        _deprecated("TdmsChannel.property", "Use TdmsChannel.properties[property_name]")
 
         try:
             return self.properties[property_name]
@@ -628,24 +648,30 @@ class TdmsChannel(object):
 
     @_property_builtin
     def group(self):
-        """ Returns the name of the group for this object,
+        """ (Deprecated) Returns the name of the group for this object,
             or None if it is the root object.
         """
+        _deprecated("TdmsChannel.group")
         return self._path.group
 
     @_property_builtin
     def channel(self):
-        """ Returns the name of the channel for this object,
+        """ (Deprecated) Returns the name of the channel for this object,
             or None if it is a group or the root object.
         """
+        _deprecated("TdmsChannel.channel", "Use TdmsChannel.name")
         return self._path.channel
 
     @_property_builtin
     def has_data(self):
+        """Deprecated"""
+        _deprecated("TdmsChannel.has_data", "This always returns True")
         return True
 
     @_property_builtin
     def number_values(self):
+        """(Deprecated)"""
+        _deprecated("TdmsChannel.number_values", "Use len(channel)")
         return self._length
 
 
@@ -662,12 +688,22 @@ class RootObject(object):
 
     @_property_builtin
     def group(self):
+        _deprecated("RootObject", "Use TdmsFile.properties to access properties from the root object")
         return None
 
     @_property_builtin
     def channel(self):
+        _deprecated("RootObject", "Use TdmsFile.properties to access properties from the root object")
         return None
 
     @_property_builtin
     def has_data(self):
+        _deprecated("RootObject", "Use TdmsFile.properties to access properties from the root object")
         return False
+
+
+def _deprecated(name, detail=None):
+    message = "'{0}' is deprecated and will be removed in a future release.".format(name)
+    if detail is not None:
+        message += " {0}".format(detail)
+    log.warn(message)

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -3,6 +3,7 @@
     This module contains the public facing API for reading TDMS files
 """
 
+import warnings
 import numpy as np
 
 from nptdms import scaling
@@ -707,4 +708,4 @@ def _deprecated(name, detail=None):
     message = "'{0}' is deprecated and will be removed in a future release.".format(name)
     if detail is not None:
         message += " {0}".format(detail)
-    log.warning(message)
+    warnings.warn(message)

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -680,6 +680,7 @@ class RootObject(object):
         self.properties = properties
 
     def property(self, property_name):
+        _deprecated("RootObject", "Use TdmsFile.properties to access properties from the root object")
         try:
             return self.properties[property_name]
         except KeyError:

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -706,4 +706,4 @@ def _deprecated(name, detail=None):
     message = "'{0}' is deprecated and will be removed in a future release.".format(name)
     if detail is not None:
         message += " {0}".format(detail)
-    log.warn(message)
+    log.warning(message)

--- a/nptdms/tdmsinfo.py
+++ b/nptdms/tdmsinfo.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from argparse import ArgumentParser
 import logging
 
-from nptdms import tdms
+from nptdms import TdmsFile
 from nptdms.log import log_manager
 
 
@@ -28,28 +28,18 @@ def main():
 
 
 def tdmsinfo(file, show_properties=False):
-    tdmsfile = tdms.TdmsFile(file)
+    tdmsfile = TdmsFile.read_metadata(file)
 
     level = 0
     display('/', level)
-    try:
-        root = tdmsfile.object()
-        if show_properties:
-            display_properties(root, level)
-    except KeyError:
-        # Root object isn't present
-        pass
+    if show_properties:
+        display_properties(tdmsfile, level + 1)
     for group in tdmsfile.groups():
         level = 1
-        try:
-            group_obj = tdmsfile.object(group)
-            display("%s" % group_obj.path, level)
-            if show_properties:
-                display_properties(group_obj, level)
-        except KeyError:
-            # It is possible to have a group without an object
-            display("/'%s'" % group, level)
-        for channel in tdmsfile.group_channels(group):
+        display("%s" % group.path, level)
+        if show_properties:
+            display_properties(group, level + 1)
+        for channel in group.channels():
             level = 2
             display("%s" % channel.path, level)
             if show_properties:
@@ -64,7 +54,7 @@ def display_properties(tdms_object, level):
     if tdms_object.properties:
         display("properties:", level)
         for prop, val in tdms_object.properties.items():
-            display("%s: %s" % (prop, val), level)
+            display("%s: %s" % (prop, val), level + 1)
 
 
 def display(s, level):

--- a/nptdms/test/test_daqmx.py
+++ b/nptdms/test/test_daqmx.py
@@ -28,7 +28,7 @@ def test_single_channel_i16():
     test_file.add_segment(segment_toc(), metadata, data)
     tdms_data = test_file.load()
 
-    data = tdms_data.object("Group", "Channel1").raw_data
+    data = tdms_data["Group"]["Channel1"].raw_data
 
     assert data.dtype == np.int16
     np.testing.assert_array_equal(data, [1, 2, -1, -2])
@@ -55,7 +55,7 @@ def test_single_channel_u16():
     test_file.add_segment(segment_toc(), metadata, data)
     tdms_data = test_file.load()
 
-    data = tdms_data.object("Group", "Channel1").raw_data
+    data = tdms_data["Group"]["Channel1"].raw_data
 
     assert data.dtype == np.uint16
     np.testing.assert_array_equal(data, [1, 2, 2**16 - 1, 2**16 - 2])
@@ -82,7 +82,7 @@ def test_single_channel_i32():
     test_file.add_segment(segment_toc(), metadata, data)
     tdms_data = test_file.load()
 
-    data = tdms_data.object("Group", "Channel1").raw_data
+    data = tdms_data["Group"]["Channel1"].raw_data
 
     assert data.dtype == np.int32
     np.testing.assert_array_equal(data, [1, 2, -1, -2])
@@ -109,7 +109,7 @@ def test_single_channel_u32():
     test_file.add_segment(segment_toc(), metadata, data)
     tdms_data = test_file.load()
 
-    data = tdms_data.object("Group", "Channel1").raw_data
+    data = tdms_data["Group"]["Channel1"].raw_data
 
     assert data.dtype == np.uint32
     np.testing.assert_array_equal(data, [1, 2, 2**32 - 1, 2**32 - 2])
@@ -142,11 +142,11 @@ def test_two_channel_i16():
     test_file.add_segment(segment_toc(), metadata, data)
     tdms_data = test_file.load()
 
-    data_1 = tdms_data.object("Group", "Channel1").raw_data
+    data_1 = tdms_data["Group"]["Channel1"].raw_data
     assert data_1.dtype == np.int16
     np.testing.assert_array_equal(data_1, [1, 2, 3, 4])
 
-    data_2 = tdms_data.object("Group", "Channel2").raw_data
+    data_2 = tdms_data["Group"]["Channel2"].raw_data
     assert data_2.dtype == np.int16
     np.testing.assert_array_equal(data_2, [17, 18, 19, 20])
 
@@ -176,15 +176,15 @@ def test_mixed_channel_widths():
     test_file.add_segment(segment_toc(), metadata, data)
     tdms_data = test_file.load()
 
-    data_1 = tdms_data.object("Group", "Channel1").raw_data
+    data_1 = tdms_data["Group"]["Channel1"].raw_data
     assert data_1.dtype == np.int8
     np.testing.assert_array_equal(data_1, [1, 2, 3, 4])
 
-    data_2 = tdms_data.object("Group", "Channel2").raw_data
+    data_2 = tdms_data["Group"]["Channel2"].raw_data
     assert data_2.dtype == np.int16
     np.testing.assert_array_equal(data_2, [17, 18, 19, 20])
 
-    data_3 = tdms_data.object("Group", "Channel3").raw_data
+    data_3 = tdms_data["Group"]["Channel3"].raw_data
     assert data_3.dtype == np.int32
     np.testing.assert_array_equal(data_3, [33, 34, 35, 36])
 
@@ -216,7 +216,7 @@ def test_multiple_scalers_with_same_type():
     test_file = GeneratedFile()
     test_file.add_segment(segment_toc(), metadata, data)
     tdms_data = test_file.load()
-    channel = tdms_data.object("Group", "Channel1")
+    channel = tdms_data["Group"]["Channel1"]
 
     scaler_0_data = channel.raw_scaler_data[0]
     assert scaler_0_data.dtype == np.int16
@@ -251,7 +251,7 @@ def test_multiple_scalers_with_different_types():
     test_file = GeneratedFile()
     test_file.add_segment(segment_toc(), metadata, data)
     tdms_data = test_file.load()
-    channel = tdms_data.object("Group", "Channel1")
+    channel = tdms_data["Group"]["Channel1"]
 
     scaler_0_data = channel.raw_scaler_data[0]
     assert scaler_0_data.dtype == np.int8
@@ -292,10 +292,10 @@ def test_multiple_raw_data_buffers():
     test_file.add_segment(segment_toc(), metadata, data)
     tdms_data = test_file.load()
 
-    data_1 = tdms_data.object("Group", "Channel1").raw_data
-    data_2 = tdms_data.object("Group", "Channel2").raw_data
-    data_3 = tdms_data.object("Group", "Channel3").raw_data
-    data_4 = tdms_data.object("Group", "Channel4").raw_data
+    data_1 = tdms_data["Group"]["Channel1"].raw_data
+    data_2 = tdms_data["Group"]["Channel2"].raw_data
+    data_3 = tdms_data["Group"]["Channel3"].raw_data
+    data_4 = tdms_data["Group"]["Channel4"].raw_data
 
     for data in [data_1, data_2, data_3, data_4]:
         assert data.dtype == np.int16
@@ -338,11 +338,11 @@ def test_multiple_raw_data_buffers_with_different_widths():
     test_file.add_segment(segment_toc(), metadata, data)
     tdms_data = test_file.load()
 
-    data_1 = tdms_data.object("Group", "Channel1").raw_data
-    data_2 = tdms_data.object("Group", "Channel2").raw_data
-    data_3 = tdms_data.object("Group", "Channel3").raw_data
-    data_4 = tdms_data.object("Group", "Channel4").raw_data
-    data_5 = tdms_data.object("Group", "Channel5").raw_data
+    data_1 = tdms_data["Group"]["Channel1"].raw_data
+    data_2 = tdms_data["Group"]["Channel2"].raw_data
+    data_3 = tdms_data["Group"]["Channel3"].raw_data
+    data_4 = tdms_data["Group"]["Channel4"].raw_data
+    data_5 = tdms_data["Group"]["Channel5"].raw_data
 
     for data in [data_1, data_2, data_3]:
         assert data.dtype == np.int16
@@ -382,8 +382,8 @@ def test_multiple_raw_data_buffers_with_scalers_split_across_buffers():
     test_file.add_segment(segment_toc(), metadata, data)
     tdms_data = test_file.load()
 
-    channel_1 = tdms_data.object("Group", "Channel1")
-    channel_2 = tdms_data.object("Group", "Channel2")
+    channel_1 = tdms_data["Group"]["Channel1"]
+    channel_2 = tdms_data["Group"]["Channel2"]
 
     scaler_data_1 = channel_1.raw_scaler_data[0]
     scaler_data_2 = channel_1.raw_scaler_data[1]
@@ -432,11 +432,11 @@ def test_lazily_reading_channel():
 
     with test_file.get_tempfile() as temp_file:
         with TdmsFile.open(temp_file.file) as tdms_file:
-            data_1 = tdms_file.object("Group", "Channel1").read_data()
+            data_1 = tdms_file["Group"]["Channel1"].read_data()
             assert data_1.dtype == np.int16
             np.testing.assert_array_equal(data_1, [1, 2, 3, 4])
 
-            data_2 = tdms_file.object("Group", "Channel2").read_data()
+            data_2 = tdms_file["Group"]["Channel2"].read_data()
             assert data_2.dtype == np.int16
             np.testing.assert_array_equal(data_2, [17, 18, 19, 20])
 
@@ -473,11 +473,11 @@ def test_lazily_reading_a_subset_of_channel_data():
 
     with test_file.get_tempfile() as temp_file:
         with TdmsFile.open(temp_file.file) as tdms_file:
-            data_1 = tdms_file.object("Group", "Channel1").read_data(1, 2)
+            data_1 = tdms_file["Group"]["Channel1"].read_data(1, 2)
             assert data_1.dtype == np.int16
             np.testing.assert_array_equal(data_1, [2, 3])
 
-            data_2 = tdms_file.object("Group", "Channel2").read_data(1, 2)
+            data_2 = tdms_file["Group"]["Channel2"].read_data(1, 2)
             assert data_2.dtype == np.int16
             np.testing.assert_array_equal(data_2, [18, 19])
 

--- a/nptdms/test/test_example_files.py
+++ b/nptdms/test/test_example_files.py
@@ -17,7 +17,7 @@ def test_labview_file():
     channel = "Dev1_port3_line7 - line 0"
     expected = np.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1], dtype=np.uint8)
 
-    data = test_file.object(group, channel).data
+    data = test_file[group][channel].data
     np.testing.assert_almost_equal(data[:10], expected)
 
 
@@ -36,7 +36,7 @@ def test_raw_format():
 def test_big_endian_format():
     """Test reading a file that encodes data in big endian mode"""
     test_file = tdms.TdmsFile(DATA_DIR + '/big_endian.tdms')
-    data = test_file.object('Measured Data', 'Phase sweep').data
+    data = test_file['Measured Data']['Phase sweep'].data
     np.testing.assert_almost_equal(data[:10],
                                    [0.0000000, 0.0634176, 0.1265799,
                                     0.1892325, 0.2511234, 0.3120033,

--- a/nptdms/test/test_example_files.py
+++ b/nptdms/test/test_example_files.py
@@ -24,8 +24,8 @@ def test_labview_file():
 def test_raw_format():
     """Test reading a file with DAQmx raw data"""
     test_file = tdms.TdmsFile(DATA_DIR + '/raw1.tdms')
-    obj_path = test_file.groups()[0]
-    data = test_file.object(obj_path, 'First  Channel').data
+    group = test_file.groups()[0]
+    data = group['First  Channel'].data
     np.testing.assert_almost_equal(data[:10],
                                    [-0.18402661, 0.14801477, -0.24506363,
                                     -0.29725028, -0.20020142, 0.18158513,

--- a/nptdms/test/test_hdf.py
+++ b/nptdms/test/test_hdf.py
@@ -214,7 +214,7 @@ def test_as_hdf_string(tmp_path):
     test_file.add_segment(toc, metadata, data)
     tdms_data = test_file.load()
 
-    data = tdms_data.channel_data("Group", "String")
+    data = tdms_data["Group"]["String"].data
     assert len(data) == len(strings)
     for expected, read in zip(strings, data):
         assert expected == read
@@ -268,7 +268,7 @@ def test_unicode_string_data(tmp_path):
     test_file.add_segment(toc, metadata, data)
     tdms_data = test_file.load()
 
-    data = tdms_data.channel_data("Group", "String")
+    data = tdms_data["Group"]["String"].data
     assert len(data) == len(strings)
     for expected, read in zip(strings, data):
         assert expected == read

--- a/nptdms/test/test_pandas.py
+++ b/nptdms/test/test_pandas.py
@@ -192,7 +192,7 @@ def test_group_as_dataframe():
     test_file.add_segment(*timed_segment())
     tdms_data = test_file.load()
 
-    df = tdms_data.object("Group").as_dataframe()
+    df = tdms_data["Group"].as_dataframe()
     assert len(df) == 2
     assert len(df.keys()) == 2
     assert "Channel1" in df.keys()
@@ -208,7 +208,7 @@ def test_channel_as_dataframe():
     test_file.add_segment(*timed_segment())
     tdms_data = test_file.load()
 
-    df = tdms_data.object("Group", "Channel2").as_dataframe()
+    df = tdms_data["Group"]["Channel2"].as_dataframe()
     assert len(df) == 2
     assert len(df.keys()) == 1
     assert "/'Group'/'Channel2'" in df.keys()
@@ -222,7 +222,7 @@ def test_channel_as_dataframe_with_time():
     test_file.add_segment(*timed_segment())
     tdms_data = test_file.load()
 
-    df = tdms_data.object("Group", "Channel2").as_dataframe()
+    df = tdms_data["Group"]["Channel2"].as_dataframe()
 
     assert len(df.index) == 2
     assert within_tol(df.index[0], 2.0)
@@ -236,7 +236,7 @@ def test_channel_as_dataframe_without_time():
     test_file.add_segment(*basic_segment())
     tdms_data = test_file.load()
 
-    df = tdms_data.object("Group", "Channel2").as_dataframe()
+    df = tdms_data["Group"]["Channel2"].as_dataframe()
 
     assert len(df.index) == 2
     assert len(df.values) == 2
@@ -253,8 +253,7 @@ def test_channel_as_dataframe_with_absolute_time():
     test_file.add_segment(*timed_segment())
     tdms_data = test_file.load()
 
-    df = tdms_data.object("Group", "Channel1").as_dataframe(
-        absolute_time=True)
+    df = tdms_data["Group"]["Channel1"].as_dataframe(absolute_time=True)
 
     expected_start = datetime(2015, 9, 8, 10, 5, 49)
     assert (df.index == expected_start)[0]

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -27,7 +27,7 @@ def test_read_channel_data(test_file, expected_data):
         tdms_data = TdmsFile.read(temp_file.file)
 
     for ((group, channel), expected_data) in expected_data.items():
-        actual_data = tdms_data.object(group, channel).data
+        actual_data = tdms_data[group][channel].data
         assert actual_data.dtype == expected_data.dtype
         compare_arrays(actual_data, expected_data)
 
@@ -39,7 +39,7 @@ def test_lazily_read_channel_data(test_file, expected_data):
     with test_file.get_tempfile() as temp_file:
         with TdmsFile.open(temp_file.file) as tdms_file:
             for ((group, channel), expected_data) in expected_data.items():
-                actual_data = tdms_file.object(group, channel).read_data()
+                actual_data = tdms_file[group][channel].read_data()
                 assert actual_data.dtype == expected_data.dtype
                 compare_arrays(actual_data, expected_data)
 
@@ -53,7 +53,7 @@ def test_lazily_read_channel_data_with_file_path():
         temp_file.file.close()
         with TdmsFile.open(temp_file.name) as tdms_file:
             for ((group, channel), expected_data) in expected_data.items():
-                actual_data = tdms_file.object(group, channel).read_data()
+                actual_data = tdms_file[group][channel].read_data()
                 assert actual_data.dtype == expected_data.dtype
                 compare_arrays(actual_data, expected_data)
     finally:
@@ -103,7 +103,7 @@ def test_reading_subset_of_data(offset, length):
 
     with test_file.get_tempfile() as temp_file:
         with TdmsFile.open(temp_file.file) as tdms_file:
-            channel_subset = tdms_file.object('group', 'channel1').read_data(offset, length)
+            channel_subset = tdms_file['group']['channel1'].read_data(offset, length)
             expected_data = channel_data[offset:offset + length]
             assert len(channel_subset) == len(expected_data)
             np.testing.assert_equal(channel_subset, expected_data)
@@ -118,7 +118,7 @@ def test_reading_subset_of_data_for_scenario(test_file, expected_data, offset, l
     with test_file.get_tempfile() as temp_file:
         with TdmsFile.open(temp_file.file) as tdms_file:
             for ((group, channel), expected_data) in expected_data.items():
-                actual_data = tdms_file.object(group, channel).read_data(offset, length)
+                actual_data = tdms_file[group][channel].read_data(offset, length)
                 compare_arrays(actual_data, expected_data[offset:offset + length])
 
 
@@ -130,7 +130,7 @@ def test_invalid_offset_throws():
     with test_file.get_tempfile() as temp_file:
         with TdmsFile.open(temp_file.file) as tdms_file:
             with pytest.raises(ValueError) as exc_info:
-                tdms_file.object(group, channel).read_data(-1, 5)
+                tdms_file[group][channel].read_data(-1, 5)
             assert "offset must be non-negative" in str(exc_info.value)
 
 
@@ -142,7 +142,7 @@ def test_invalid_length_throws():
     with test_file.get_tempfile() as temp_file:
         with TdmsFile.open(temp_file.file) as tdms_file:
             with pytest.raises(ValueError) as exc_info:
-                tdms_file.object(group, channel).read_data(0, -5)
+                tdms_file[group][channel].read_data(0, -5)
             assert "length must be non-negative" in str(exc_info.value)
 
 
@@ -155,7 +155,7 @@ def test_read_data_after_close_throws():
         with TdmsFile.open(temp_file.file) as tdms_file:
             pass
         with pytest.raises(RuntimeError) as exc_info:
-            tdms_file.object(group, channel).read_data()
+            tdms_file[group][channel].read_data()
         assert "Cannot read channel data after the underlying TDMS reader is closed" in str(exc_info.value)
 
 
@@ -167,7 +167,7 @@ def test_read_data_after_open_in_read_mode_throws():
     with test_file.get_tempfile() as temp_file:
         tdms_file = TdmsFile.read(temp_file.file)
         with pytest.raises(RuntimeError) as exc_info:
-            tdms_file.object(group, channel).read_data()
+            tdms_file[group][channel].read_data()
         assert "Cannot read channel data after the underlying TDMS reader is closed" in str(exc_info.value)
 
 
@@ -179,15 +179,15 @@ def test_access_data_property_after_opening_throws():
     with test_file.get_tempfile() as temp_file:
         with TdmsFile.open(temp_file.file) as tdms_file:
             with pytest.raises(RuntimeError) as exc_info:
-                _ = tdms_file.object(group, channel).data
+                _ = tdms_file[group][channel].data
             assert "Channel data has not been read" in str(exc_info.value)
 
             with pytest.raises(RuntimeError) as exc_info:
-                _ = tdms_file.object(group, channel).raw_data
+                _ = tdms_file[group][channel].raw_data
             assert "Channel data has not been read" in str(exc_info.value)
 
             with pytest.raises(RuntimeError) as exc_info:
-                _ = tdms_file.object(group, channel).raw_scaler_data
+                _ = tdms_file[group][channel].raw_scaler_data
             assert "Channel data has not been read" in str(exc_info.value)
 
 
@@ -206,15 +206,15 @@ def test_get_objects():
     assert "/'Group'/'Channel2'" in objects.keys()
 
 
-def test_property_read():
-    """Test reading an object property"""
+def test_group_property_read():
+    """Test reading property of a group"""
 
     test_file = GeneratedFile()
     test_file.add_segment(*basic_segment())
     tdms_data = test_file.load()
 
-    obj = tdms_data.object("Group")
-    assert obj.property("num") == 10
+    group = tdms_data["Group"]
+    assert group.properties["num"] == 10
 
 
 def test_time_track():
@@ -225,9 +225,9 @@ def test_time_track():
     test_file.add_segment(toc, metadata, data)
     tdms_data = test_file.load()
 
-    obj = tdms_data.object("Group", "Channel2")
-    time = obj.time_track()
-    assert len(time) == len(obj.data)
+    channel = tdms_data["Group"]["Channel2"]
+    time = channel.time_track()
+    assert len(time) == len(channel.data)
     epsilon = 1.0E-15
     assert abs(time[0]) < epsilon
     assert abs(time[1] - 0.1) < epsilon
@@ -240,11 +240,11 @@ def test_memmapped_read():
     test_file.add_segment(*basic_segment())
     tdms_data = test_file.load(memmap_dir=tempfile.gettempdir())
 
-    data = tdms_data.channel_data("Group", "Channel1")
+    data = tdms_data["Group"]["Channel1"].data
     assert len(data) == 2
     assert data[0] == 1
     assert data[1] == 2
-    data = tdms_data.channel_data("Group", "Channel2")
+    data = tdms_data["Group"]["Channel2"].data
     assert len(data) == 2
     assert data[0] == 3
     assert data[1] == 4
@@ -287,7 +287,7 @@ def test_string_data():
     test_file.add_segment(toc, metadata, data)
     tdms_data = test_file.load()
 
-    data = tdms_data.channel_data("Group", "StringChannel")
+    data = tdms_data["Group"]["StringChannel"].data
     assert len(data) == len(strings)
     for expected, read in zip(strings, data):
         assert expected == read
@@ -315,11 +315,11 @@ def test_slash_and_space_in_name():
     tdms_data = test_file.load()
 
     assert len(tdms_data.groups()) == 2
-    assert len(tdms_data.group_channels(group_1)) == 1
-    assert len(tdms_data.group_channels(group_2)) == 1
-    data_1 = tdms_data.channel_data(group_1, channel_1)
+    assert len(tdms_data[group_1].channels()) == 1
+    assert len(tdms_data[group_2].channels()) == 1
+    data_1 = tdms_data[group_1][channel_1].data
     assert len(data_1) == 2
-    data_2 = tdms_data.channel_data(group_2, channel_2)
+    data_2 = tdms_data[group_2][channel_2].data
     assert len(data_2) == 2
 
 
@@ -339,8 +339,8 @@ def test_single_quote_in_name():
     tdms_data = test_file.load()
 
     assert len(tdms_data.groups()) == 1
-    assert len(tdms_data.group_channels("group's name")) == 1
-    data_1 = tdms_data.channel_data("group's name", "channel's name")
+    assert len(tdms_data["group's name"].channels()) == 1
+    data_1 = tdms_data["group's name"]["channel's name"].data
     assert len(data_1) == 2
 
 
@@ -361,7 +361,9 @@ def test_group_object_paths():
     test_file.add_segment(*basic_segment())
     tdms_data = test_file.load()
 
-    obj = tdms_data.object("Group")
+    obj = tdms_data["Group"]
+    assert obj.path == "/'Group'"
+    assert obj.name == "Group"
     assert obj.group == "Group"
     assert obj.channel is None
 
@@ -372,7 +374,9 @@ def test_channel_object_paths():
     test_file.add_segment(*basic_segment())
     tdms_data = test_file.load()
 
-    obj = tdms_data.object("Group", "Channel1")
+    obj = tdms_data["Group"]["Channel1"]
+    assert obj.path == "/'Group'/'Channel1'"
+    assert obj.name == "Channel1"
     assert obj.group == "Group"
     assert obj.channel == "Channel1"
 
@@ -384,11 +388,11 @@ def test_data_read_from_bytes_io():
     test_file.add_segment(*basic_segment())
     tdms_data = test_file.load()
 
-    data = tdms_data.channel_data("Group", "Channel1")
+    data = tdms_data["Group"]["Channel1"].data
     assert len(data) == 2
     assert data[0] == 1
     assert data[1] == 2
-    data = tdms_data.channel_data("Group", "Channel2")
+    data = tdms_data["Group"]["Channel2"].data
     assert len(data) == 2
     assert data[0] == 3
     assert data[1] == 4

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -60,6 +60,7 @@ def test_lazily_read_channel_data_with_file_path():
         os.remove(temp_file.name)
 
 
+@pytest.mark.filterwarnings('ignore:.* is deprecated')
 def test_lazily_read_channel_data_with_channel_data_method():
     """Test reading channel data lazily using the channel_data method of TdmsFile
     """
@@ -191,6 +192,7 @@ def test_access_data_property_after_opening_throws():
             assert "Channel data has not been read" in str(exc_info.value)
 
 
+@pytest.mark.filterwarnings('ignore:.* is deprecated')
 def test_get_objects():
     """Test reading data"""
 
@@ -344,6 +346,7 @@ def test_single_quote_in_name():
     assert len(data_1) == 2
 
 
+@pytest.mark.filterwarnings('ignore:.* is deprecated')
 def test_root_object_paths():
     """Test the group and channel properties for the root object"""
     test_file = GeneratedFile()
@@ -355,6 +358,7 @@ def test_root_object_paths():
     assert obj.channel is None
 
 
+@pytest.mark.filterwarnings('ignore:.* is deprecated')
 def test_group_object_paths():
     """Test the group and channel properties for a group"""
     test_file = GeneratedFile()
@@ -368,6 +372,7 @@ def test_group_object_paths():
     assert obj.channel is None
 
 
+@pytest.mark.filterwarnings('ignore:.* is deprecated')
 def test_channel_object_paths():
     """Test the group and channel properties for a group"""
     test_file = GeneratedFile()

--- a/nptdms/test/test_tdmsinfo.py
+++ b/nptdms/test/test_tdmsinfo.py
@@ -1,0 +1,25 @@
+import os
+from nptdms.tdmsinfo import tdmsinfo
+from nptdms.test.util import GeneratedFile, basic_segment
+
+
+def test_tdmsinfo():
+    test_file = GeneratedFile()
+    test_file.add_segment(*basic_segment())
+    temp_file = test_file.get_tempfile(delete=False)
+    try:
+        temp_file.file.close()
+        tdmsinfo(temp_file.name)
+    finally:
+        os.remove(temp_file.name)
+
+
+def test_tdmsinfo_with_properties():
+    test_file = GeneratedFile()
+    test_file.add_segment(*basic_segment())
+    temp_file = test_file.get_tempfile(delete=False)
+    try:
+        temp_file.file.close()
+        tdmsinfo(temp_file.name, show_properties=True)
+    finally:
+        os.remove(temp_file.name)

--- a/nptdms/test/writer/test_acceptance_tests.py
+++ b/nptdms/test/writer/test_acceptance_tests.py
@@ -23,8 +23,8 @@ def test_can_read_tdms_file_after_writing():
     output_file.seek(0)
     tdms_file = TdmsFile(output_file)
 
-    a_output = tdms_file.object("group", "a").data
-    b_output = tdms_file.object("group", "b").data
+    a_output = tdms_file["group"]["a"].data
+    b_output = tdms_file["group"]["b"].data
 
     assert len(a_output) == len(a_input)
     assert len(b_output) == len(b_input)
@@ -51,15 +51,15 @@ def test_can_read_tdms_file_properties_after_writing():
     output_file.seek(0)
     tdms_file = TdmsFile(output_file)
 
-    a_output = tdms_file.object()
-    b_output = tdms_file.object("group_name")
+    file_properties = tdms_file.properties
+    b_output = tdms_file["group_name"]
 
-    assert "prop1" in a_output.properties, "prop1 not found"
-    assert "prop2" in a_output.properties, "prop2 not found"
+    assert "prop1" in file_properties, "prop1 not found"
+    assert "prop2" in file_properties, "prop2 not found"
     assert "prop3" in b_output.properties, "prop3 not found"
     assert "prop4" in b_output.properties, "prop4 not found"
-    assert a_output.properties["prop1"] == "foo"
-    assert a_output.properties["prop2"] == 3
+    assert file_properties["prop1"] == "foo"
+    assert file_properties["prop2"] == 3
     assert b_output.properties["prop3"] == 1.2345
     assert b_output.properties["prop4"] == test_time
 
@@ -79,7 +79,7 @@ def test_can_write_multiple_segments():
     output_file.seek(0)
     tdms_file = TdmsFile(output_file)
 
-    output_data = tdms_file.object("group", "a").data
+    output_data = tdms_file["group"]["a"].data
 
     expected_data = np.append(input_1, input_2)
     assert len(output_data) == len(expected_data)
@@ -117,7 +117,7 @@ def test_can_append_to_file_using_path():
 
         tdms_file = TdmsFile(temppath)
 
-        output = tdms_file.object("group", "a").data
+        output = tdms_file["group"]["a"].data
 
         assert len(output) == 20
         np.testing.assert_almost_equal(
@@ -155,17 +155,16 @@ def test_can_write_tdms_objects_read_from_file():
             tdms_writer.write_segment([group_segment, channel_segment])
 
         tdms_file = TdmsFile(temppath)
-        read_group = tdms_file.object("group")
-        read_channel = tdms_file.object("group", "a")
+        read_group = tdms_file["group"]
+        read_channel = tdms_file["group"]["a"]
 
         with TdmsWriter(temppath) as tdms_writer:
             tdms_writer.write_segment([read_group, read_channel])
 
         tdms_file = TdmsFile(temppath)
-        read_group = tdms_file.object("group")
-        read_channel = tdms_file.object("group", "a")
+        read_group = tdms_file["group"]
+        read_channel = tdms_file["group"]["a"]
 
-        assert not read_group.has_data
         assert read_group.properties["prop1"] == "bar"
 
         assert len(read_channel.data) == 10
@@ -195,7 +194,7 @@ def test_can_write_timestamp_data():
     output_file.seek(0)
     tdms_file = TdmsFile(output_file)
 
-    output_data = tdms_file.object("group", "timedata").data
+    output_data = tdms_file["group"]["timedata"].data
 
     assert len(output_data) == 3
     assert output_data[0] == input_data[0]
@@ -222,7 +221,7 @@ def test_can_write_timestamp_data_with_datetimes():
     output_file.seek(0)
     tdms_file = TdmsFile(output_file)
 
-    output_data = tdms_file.object("group", "timedata").data
+    output_data = tdms_file["group"]["timedata"].data
 
     assert len(output_data) == 3
     assert output_data[0] == expected_data[0]
@@ -245,7 +244,7 @@ def test_can_write_numpy_timestamp_data_with_dates():
     output_file.seek(0)
     tdms_file = TdmsFile(output_file)
 
-    output_data = tdms_file.object("group", "timedata").data
+    output_data = tdms_file["group"]["timedata"].data
 
     assert len(output_data) == 3
     assert output_data[0] == input_data[0]
@@ -267,7 +266,7 @@ def test_can_write_string_data():
     output_file.seek(0)
     tdms_file = TdmsFile(output_file)
 
-    output_data = tdms_file.object("group", "string_data").data
+    output_data = tdms_file["group"]["string_data"].data
 
     assert len(output_data) == 2
     assert output_data[0] == input_data[0]
@@ -286,7 +285,7 @@ def test_can_write_floats_from_list():
     output_file.seek(0)
     tdms_file = TdmsFile(output_file)
 
-    output_data = tdms_file.object("group", "data").data
+    output_data = tdms_file["group"]["data"].data
 
     assert output_data.dtype == np.float64
     assert len(output_data) == 3
@@ -335,7 +334,7 @@ def test_can_write_ints_from_list():
         output_file.seek(0)
         tdms_file = TdmsFile(output_file)
 
-        output_data = tdms_file.object("group", "data").data
+        output_data = tdms_file["group"]["data"].data
 
         assert output_data.dtype == expected_type, test_case
         assert len(output_data) == len(input_data), test_case
@@ -360,13 +359,13 @@ def test_can_write_complex():
     output_file.seek(0)
     tdms_file = TdmsFile(output_file)
 
-    output_data = tdms_file.object("group", "complex64_data").data
+    output_data = tdms_file["group"]["complex64_data"].data
     assert output_data.dtype == np.complex64
     assert len(output_data) == 2
     assert output_data[0] == input_complex64_data[0]
     assert output_data[1] == input_complex64_data[1]
 
-    output_data = tdms_file.object("group", "complex128_data").data
+    output_data = tdms_file["group"]["complex128_data"].data
     assert output_data.dtype == np.complex128
     assert len(output_data) == 2
     assert output_data[0] == input_complex128_data[0]

--- a/nptdms/writer.py
+++ b/nptdms/writer.py
@@ -117,7 +117,7 @@ class TdmsSegment(object):
         return metadata
 
     def raw_data_index(self, obj):
-        if obj.has_data:
+        if hasattr(obj, 'data'):
             data_type = Int32(obj.data_type.enum_value)
             dimension = Uint32(1)
             num_values = Uint64(len(obj.data))
@@ -154,13 +154,13 @@ class TdmsSegment(object):
     def _data_size(self):
         data_size = 0
         for obj in self.objects:
-            if obj.has_data:
+            if hasattr(obj, 'data'):
                 data_size += object_data_size(obj.data_type, obj.data)
         return data_size
 
     def _write_data(self, file):
         for obj in self.objects:
-            if obj.has_data:
+            if hasattr(obj, 'data'):
                 write_data(file, obj)
 
 

--- a/nptdms/writer.py
+++ b/nptdms/writer.py
@@ -179,7 +179,7 @@ class TdmsObject(object):
 
 
 class RootObject(TdmsObject):
-    """The root TDMS object
+    """The root TDMS object containing properties for the TDMS file
     """
     def __init__(self, properties=None):
         """Initialise a new GroupObject

--- a/nptdms/writer.py
+++ b/nptdms/writer.py
@@ -57,7 +57,7 @@ class TdmsWriter(object):
     def close(self):
         if self._file_path is not None:
             self._file.close()
-            self._file = None
+        self._file = None
 
     def write_segment(self, objects):
         """ Write a segment of data to a TDMS file

--- a/nptdms/writer.py
+++ b/nptdms/writer.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from io import UnsupportedOperation
 import logging
 import numpy as np
-from nptdms.common import toc_properties
+from nptdms.common import toc_properties, ObjectPath
 from nptdms.types import *
 
 log = logging.getLogger(__name__)
@@ -214,7 +214,7 @@ class GroupObject(TdmsObject):
     def path(self):
         """The string representation of this group's path
         """
-        return "/'%s'" % self.group.replace("'", "''")
+        return str(ObjectPath(self.group))
 
 
 class ChannelObject(TdmsObject):
@@ -253,9 +253,7 @@ class ChannelObject(TdmsObject):
     def path(self):
         """The string representation of this channel's path
         """
-        return "/'%s'/'%s'" % (
-            self.group.replace("'", "''"),
-            self.channel.replace("'", "''"))
+        return str(ObjectPath(self.group, self.channel))
 
 
 def read_properties_dict(properties_dict):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
   author = 'Adam Reeve',
   author_email = 'adreeve@gmail.com',
   url = 'https://github.com/adamreeve/npTDMS',
-  packages = ['nptdms', 'nptdms.test'],
+  packages = ['nptdms', 'nptdms.export', 'nptdms.test'],
   long_description=open('README.rst').read(),
   license = 'LGPL',
   classifiers = [


### PR DESCRIPTION
Work towards #161. Introduces new `TdmsGroup` and `TdmsChannel` classes to replace `TdmsObject` and adds support for indexing into `TdmsFile` objects to access groups and `TdmsGroup` to access channels. Adds a deprecation warning to methods that will be removed. Updates tests and documentation to use non-deprecated methods. Most code using npTDMS should still work for now without changes, the only breaking change so far is that `groups` now returns `TdmsGroup` objects, but `group_channels` has been modified to accept these.

Also fixes #152 by changing `tdmsinfo` to read metadata only.