### PR TITLE
Fix Pandas export inconsistencies

### DIFF
--- a/nptdms/export/pandas_export.py
+++ b/nptdms/export/pandas_export.py
@@ -1,68 +1,71 @@
 from nptdms.utils import OrderedDict
 
 
-def from_tdms_file(tdms_file, time_index=False, absolute_time=False):
+def from_tdms_file(tdms_file, time_index=False, absolute_time=False, scaled_data=True):
     """
-    Converts the TDMS file to a DataFrame
+    Converts the TDMS file to a DataFrame. DataFrame columns are named using the TDMS object paths.
 
     :param tdms_file: TDMS file object to convert.
     :param time_index: Whether to include a time index for the dataframe.
     :param absolute_time: If time_index is true, whether the time index
         values are absolute times or relative to the start time.
+    :param scaled_data: By default the scaled data will be used.
+        Set to False to use raw unscaled data.
     :return: The full TDMS file data.
     :rtype: pandas.DataFrame
     """
 
+    channels_to_export = OrderedDict()
+    for group in tdms_file.groups():
+        for channel in group.channels():
+            channels_to_export[channel.path] = channel
+    return _channels_to_dataframe(channels_to_export, time_index, absolute_time, scaled_data)
+
+
+def from_group(group, time_index=False, absolute_time=False, scaled_data=True):
+    """
+    Converts a TDMS group object to a DataFrame. DataFrame columns are named using the channel names.
+
+    :param group: Group object to convert.
+    :param time_index: Whether to include a time index for the dataframe.
+    :param absolute_time: If time_index is true, whether the time index
+        values are absolute times or relative to the start time.
+    :param scaled_data: By default the scaled data will be used.
+        Set to False to use raw unscaled data.
+    :return: The TDMS object data.
+    :rtype: pandas.DataFrame
+    """
+
+    channels_to_export = OrderedDict((ch.name, ch) for ch in group.channels())
+    return _channels_to_dataframe(channels_to_export, time_index, absolute_time, scaled_data)
+
+
+def from_channel(channel, time_index=False, absolute_time=False, scaled_data=True):
+    """
+    Converts the TDMS channel to a DataFrame
+
+    :param channel: Channel object to convert.
+    :param time_index: Whether to include a time index for the dataframe.
+    :param absolute_time: If time_index is true, whether the time index
+        values are absolute times or relative to the start time.
+    :param scaled_data: By default the scaled data will be used.
+        Set to False to use raw unscaled data.
+    :return: The TDMS object data.
+    :rtype: pandas.DataFrame
+    """
+
+    channels_to_export = {channel.path: channel}
+    return _channels_to_dataframe(channels_to_export, time_index, absolute_time, scaled_data)
+
+
+def _channels_to_dataframe(channels_to_export, time_index=False, absolute_time=False, scaled_data=True):
     import pandas as pd
 
     dataframe_dict = OrderedDict()
-    for group in tdms_file.groups():
-        for channel in group.channels():
-            index = channel.time_track(absolute_time) if time_index else None
-            dataframe_dict[channel.path] = pd.Series(data=channel.data, index=index)
+    for column_name, channel in channels_to_export.items():
+        index = channel.time_track(absolute_time) if time_index else None
+        dataframe_dict[column_name] = pd.Series(data=_get_data(channel, scaled_data), index=index)
     return pd.DataFrame.from_dict(dataframe_dict)
-
-
-def from_group(group, scaled_data=True):
-    """
-    Converts a TDMS group object to a DataFrame
-
-    :param group: Group object to convert.
-    :param scaled_data: Whether to return scaled or raw data.
-    :return: The TDMS object data.
-    :rtype: pandas.DataFrame
-    """
-
-    import pandas as pd
-
-    return pd.DataFrame.from_dict(OrderedDict(
-        (ch.name, pd.Series(_get_data(ch, scaled_data)))
-        for ch in group.channels()))
-
-
-def from_channel(channel, absolute_time=False, scaled_data=True):
-    """
-    Converts the TDMS object to a DataFrame
-
-    :param channel: Channel object to convert.
-    :param absolute_time: Whether times should be absolute rather than
-        relative to the start time.
-    :param scaled_data: Whether to return scaled or raw data.
-    :return: The TDMS object data.
-    :rtype: pandas.DataFrame
-    """
-
-    import pandas as pd
-
-    # When absolute_time is True,
-    # use the wf_start_time as offset for the time_track()
-    try:
-        time = channel.time_track(absolute_time)
-    except KeyError:
-        time = None
-
-    return pd.DataFrame(
-        _get_data(channel, scaled_data), index=time, columns=[channel.path])
 
 
 def _get_data(chan, scaled_data):

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -118,18 +118,20 @@ class TdmsFile(object):
 
         return self._properties
 
-    def as_dataframe(self, time_index=False, absolute_time=False):
+    def as_dataframe(self, time_index=False, absolute_time=False, scaled_data=True):
         """
-        Converts the TDMS file to a DataFrame
+        Converts the TDMS file to a DataFrame. DataFrame columns are named using the TDMS object paths.
 
         :param time_index: Whether to include a time index for the dataframe.
         :param absolute_time: If time_index is true, whether the time index
             values are absolute times or relative to the start time.
+        :param scaled_data: By default the scaled data will be used.
+            Set to False to use raw unscaled data.
         :return: The full TDMS file data.
         :rtype: pandas.DataFrame
         """
 
-        return pandas_export.from_tdms_file(self, time_index, absolute_time)
+        return pandas_export.from_tdms_file(self, time_index, absolute_time, scaled_data)
 
     def as_hdf(self, filepath, mode='w', group='/'):
         """
@@ -381,18 +383,20 @@ class TdmsGroup(object):
         """
         return list(self._channels.values())
 
-    def as_dataframe(self, absolute_time=False, scaled_data=True):
+    def as_dataframe(self, time_index=False, absolute_time=False, scaled_data=True):
         """
-        Converts the TDMS group to a DataFrame
+        Converts the TDMS group to a DataFrame. DataFrame columns are named using the channel names.
 
-        :param absolute_time: Whether times should be absolute rather than
-            relative to the start time.
-        :param scaled_data: Whether to return scaled or raw data.
+        :param time_index: Whether to include a time index for the dataframe.
+        :param absolute_time: If time_index is true, whether the time index
+            values are absolute times or relative to the start time.
+        :param scaled_data: By default the scaled data will be used.
+            Set to False to use raw unscaled data.
         :return: The TDMS object data.
         :rtype: pandas.DataFrame
         """
 
-        return pandas_export.from_group(self, scaled_data)
+        return pandas_export.from_group(self, time_index, absolute_time, scaled_data)
 
     def __getitem__(self, channel_name):
         """ Retrieve a TDMS channel from this group by name
@@ -601,18 +605,20 @@ class TdmsChannel(object):
         return (np.datetime64(start_time) +
                 (relative_time * unit_correction).astype(time_type))
 
-    def as_dataframe(self, absolute_time=False, scaled_data=True):
+    def as_dataframe(self, time_index=False, absolute_time=False, scaled_data=True):
         """
-        Converts the TDMS channel to a DataFrame
+        Converts the TDMS channel to a DataFrame. The DataFrame column is named using the channel path.
 
-        :param absolute_time: Whether times should be absolute rather than
-            relative to the start time.
-        :param scaled_data: Whether to return scaled or raw data.
+        :param time_index: Whether to include a time index for the dataframe.
+        :param absolute_time: If time_index is true, whether the time index
+            values are absolute times or relative to the start time.
+        :param scaled_data: By default the scaled data will be used.
+            Set to False to use raw unscaled data.
         :return: The TDMS object data.
         :rtype: pandas.DataFrame
         """
 
-        return pandas_export.from_channel(self, absolute_time, scaled_data)
+        return pandas_export.from_channel(self, time_index, absolute_time, scaled_data)
 
     def _scale_data(self, raw_data):
         scale = self._get_scaling()

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -127,6 +127,7 @@ class TdmsFile(object):
             values are absolute times or relative to the start time.
         :param scaled_data: By default the scaled data will be used.
             Set to False to use raw unscaled data.
+            For DAQmx data, there will be one column per DAQmx raw scaler and column names will include the scale id.
         :return: The full TDMS file data.
         :rtype: pandas.DataFrame
         """
@@ -392,6 +393,7 @@ class TdmsGroup(object):
             values are absolute times or relative to the start time.
         :param scaled_data: By default the scaled data will be used.
             Set to False to use raw unscaled data.
+            For DAQmx data, there will be one column per DAQmx raw scaler and column names will include the scale id.
         :return: The TDMS object data.
         :rtype: pandas.DataFrame
         """
@@ -614,6 +616,7 @@ class TdmsChannel(object):
             values are absolute times or relative to the start time.
         :param scaled_data: By default the scaled data will be used.
             Set to False to use raw unscaled data.
+            For DAQmx data, there will be one column per DAQmx raw scaler and column names will include the scale id.
         :return: The TDMS object data.
         :rtype: pandas.DataFrame
         """

--- a/nptdms/test/test_pandas.py
+++ b/nptdms/test/test_pandas.py
@@ -15,8 +15,8 @@ from nptdms.test.util import (
 )
 
 
-def within_tol(a, b, tol=1.0e-10):
-    return abs(a - b) < tol
+def assert_within_tol(a, b, tol=1.0e-10):
+    assert abs(a - b) < tol
 
 
 def timed_segment():
@@ -168,8 +168,8 @@ def test_file_as_dataframe_with_time():
     df = tdms_data.as_dataframe(time_index=True)
 
     assert len(df.index) == 2
-    assert within_tol(df.index[0], 2.0)
-    assert within_tol(df.index[1], 2.1)
+    assert_within_tol(df.index[0], 2.0)
+    assert_within_tol(df.index[1], 2.1)
 
 
 def test_file_as_dataframe_with_absolute_time():
@@ -222,11 +222,11 @@ def test_channel_as_dataframe_with_time():
     test_file.add_segment(*timed_segment())
     tdms_data = test_file.load()
 
-    df = tdms_data["Group"]["Channel2"].as_dataframe()
+    df = tdms_data["Group"]["Channel2"].as_dataframe(time_index=True)
 
     assert len(df.index) == 2
-    assert within_tol(df.index[0], 2.0)
-    assert within_tol(df.index[1], 2.1)
+    assert_within_tol(df.index[0], 2.0)
+    assert_within_tol(df.index[1], 2.1)
 
 
 def test_channel_as_dataframe_without_time():
@@ -240,10 +240,10 @@ def test_channel_as_dataframe_without_time():
 
     assert len(df.index) == 2
     assert len(df.values) == 2
-    assert within_tol(df.index[0], 0.0)
-    assert within_tol(df.index[1], 0.1)
-    assert within_tol(df.values[0], 3.0)
-    assert within_tol(df.values[1], 4.0)
+    assert_within_tol(df.index[0], 0)
+    assert_within_tol(df.index[1], 1)
+    assert_within_tol(df.values[0], 3.0)
+    assert_within_tol(df.values[1], 4.0)
 
 
 def test_channel_as_dataframe_with_absolute_time():
@@ -253,7 +253,7 @@ def test_channel_as_dataframe_with_absolute_time():
     test_file.add_segment(*timed_segment())
     tdms_data = test_file.load()
 
-    df = tdms_data["Group"]["Channel1"].as_dataframe(absolute_time=True)
+    df = tdms_data["Group"]["Channel1"].as_dataframe(time_index=True, absolute_time=True)
 
     expected_start = datetime(2015, 9, 8, 10, 5, 49)
     assert (df.index == expected_start)[0]


### PR DESCRIPTION
* Support a time index when exporting a group
* Always default time_index to False when exporting files, groups and channels
* Support the scaled_data option for all export methods
* Support export of raw DAQmx data when there are multiple scalers