### PR TITLE
Support streaming of data

### DIFF
--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -18,6 +18,15 @@ Reading TDMS Files
   :members:
   :exclude-members: group, channel, has_data, property, number_values
 
+.. autoclass:: DataChunk()
+  :members:
+
+.. autoclass:: GroupDataChunk()
+  :members:
+
+.. autoclass:: ChannelDataChunk()
+  :members:
+
 Writing TDMS Files
 ------------------
 

--- a/docs/reading.rst
+++ b/docs/reading.rst
@@ -79,6 +79,23 @@ For example, to read 200 data points, beginning at offset 1,000::
         length = 200
         channel_data = channel.read_data(offset, length)
 
+Alternatively, you may have an application where you wish to stream all data chunk by chunk.
+:py:meth:`~nptdms.TdmsFile.data_chunks` is a generator that produces instances of
+:py:class:`~nptdms.DataChunk`, which can be used after opening a TDMS file with
+:py:meth:`~nptdms.TdmsFile.open`.
+For example, to compute the mean of a channel::
+
+    channel_sum = 0.0
+    channel_length = 0
+    with TdmsFile.open(tdms_file_path) as tdms_file:
+        for chunk in tdms_file.data_chunks():
+            channel_chunk = chunk[group_name][channel_name]
+            channel_length += len(channel_chunk)
+            channel_sum += channel_chunk[:].sum()
+    channel_mean = channel_sum / channel_length
+
+This approach can also be useful to stream TDMS data to another format on disk or into a data store.
+
 In cases where you don't need to read the file data and only need to read metadata, you can
 also use the static :py:meth:`~nptdms.TdmsFile.read_metadata` method::
 

--- a/docs/writing.rst
+++ b/docs/writing.rst
@@ -7,22 +7,22 @@ speeding up the writing of files and minimising file size are not
 implemented by npTDMS, but the basic functionality required to
 write TDMS files is available.
 
-To write a TDMS file, the :py:class:`nptdms.TdmsWriter` class is used, which
+To write a TDMS file, the :py:class:`~nptdms.TdmsWriter` class is used, which
 should be used as a context manager.
-The ``__init__`` method accepts the path to the file to create, or a file
+The :py:meth:`~nptdms.TdmsWriter.__init__` method accepts the path to the file to create, or a file
 that has already been opened in binary write mode::
 
     with TdmsWriter("my_file.tdms") as tdms_writer:
         # write data
 
-The :py:meth:`nptdms.TdmsWriter.write_segment` method is used to write
+The :py:meth:`~nptdms.TdmsWriter.write_segment` method is used to write
 a segment of data to the TDMS file. Because the TDMS file format is designed
 for streaming data applications, it supports writing data one segment at a time
 as data becomes available.
 If you don't require this functionality you can simple call ``write_segment`` once
 with all of your data.
 
-The ``write_segment`` method takes a list of objects, each of which must be an
+The :py:meth:`~nptdms.TdmsWriter.write_segment` method takes a list of objects, each of which must be an
 instance of one of:
 
 - :py:class:`nptdms.RootObject`. This is the TDMS root object, and there may only be one root object in a segment.
@@ -69,7 +69,7 @@ is given below::
             channel_object])
 
 You could also read a TDMS file and then re-write it by passing
-:py:class:`nptdms.TdmsGroup` and :py:class:`nptdms.TdmsChannel`
+:py:class:`~nptdms.TdmsGroup` and :py:class:`~nptdms.TdmsChannel`
 instances to the ``write_segment`` method. If you want
 to only copy certain channels for example, you could do something like::
 
@@ -83,3 +83,6 @@ to only copy certain channels for example, you could do something like::
         root_object = RootObject(original_file.properties)
         channels_to_copy = [chan for chan in original_channels if include_channel(chan)]
         copied_file.write_segment([root_object] + original_groups + channels_to_copy)
+
+Note that this isn't suitable for copying channels with scaled data, as the channel data
+will already have scaling applied.

--- a/nptdms/__init__.py
+++ b/nptdms/__init__.py
@@ -7,5 +7,5 @@ from __future__ import absolute_import
 from .version import __version_info__, __version__
 
 # Export public objects
-from .tdms import TdmsFile, TdmsGroup, TdmsChannel
+from .tdms import TdmsFile, TdmsGroup, TdmsChannel, DataChunk, GroupDataChunk, ChannelDataChunk
 from .writer import TdmsWriter, RootObject, GroupObject, ChannelObject

--- a/nptdms/base_segment.py
+++ b/nptdms/base_segment.py
@@ -182,12 +182,12 @@ class BaseSegment(object):
     def read_raw_data(self, f):
         """Read raw data from a TDMS segment
 
-        :returns: A generator of DataChunk objects with raw channel data for
+        :returns: A generator of RawDataChunk objects with raw channel data for
             objects in this segment.
         """
 
         if not self.toc_mask & toc_properties['kTocRawData']:
-            yield DataChunk.empty()
+            yield RawDataChunk.empty()
 
         f.seek(self.data_position)
 
@@ -325,7 +325,7 @@ class BaseSegmentObject(object):
         return None
 
 
-class DataChunk(object):
+class RawDataChunk(object):
     """Data read from a single chunk in a TDMS segment
 
     :ivar raw_data: A dictionary of object data in this chunk for standard
@@ -341,15 +341,15 @@ class DataChunk(object):
 
     @staticmethod
     def empty():
-        return DataChunk({}, {})
+        return RawDataChunk({}, {})
 
     @staticmethod
     def channel_data(data):
-        return DataChunk(data, {})
+        return RawDataChunk(data, {})
 
     @staticmethod
     def scaler_data(data):
-        return DataChunk({}, data)
+        return RawDataChunk({}, data)
 
 
 class ChannelDataChunk(object):

--- a/nptdms/channel_data.py
+++ b/nptdms/channel_data.py
@@ -122,6 +122,14 @@ class DaqmxDataReceiver(object):
         self._scaler_insert_positions[scale_id] += len(new_data)
 
 
+class RawChannelData(object):
+    """ Simple container for raw channel data that's already been read
+    """
+    def __init__(self, data, scaler_data):
+        self.data = data
+        self.scaler_data = scaler_data
+
+
 def _new_numpy_array(dtype, num_values, memmap_dir=None):
     """Initialise a new numpy array for data
 

--- a/nptdms/channel_data.py
+++ b/nptdms/channel_data.py
@@ -25,7 +25,7 @@ def get_data_receiver(obj, num_values, memmap_dir=None):
         return DaqmxDataReceiver(obj, num_values, memmap_dir)
 
     if obj.data_type.nptype is None:
-        return ListDataReceiver()
+        return ListDataReceiver(obj)
 
     return NumpyDataReceiver(obj, num_values, memmap_dir)
 
@@ -37,9 +37,13 @@ class ListDataReceiver(object):
        :ivar data: List of data points
     """
 
-    def __init__(self):
+    def __init__(self, channel):
         """Initialise new data receiver for a TDMS object
         """
+        if channel.data_type == types.String:
+            self._dtype = np.dtype('O')
+        else:
+            self._dtype = None
         self._data = []
         self.scaler_data = {}
 
@@ -50,7 +54,7 @@ class ListDataReceiver(object):
 
     @property
     def data(self):
-        return np.array(self._data)
+        return np.array(self._data, dtype=self._dtype)
 
 
 class NumpyDataReceiver(object):

--- a/nptdms/channel_data.py
+++ b/nptdms/channel_data.py
@@ -122,14 +122,6 @@ class DaqmxDataReceiver(object):
         self._scaler_insert_positions[scale_id] += len(new_data)
 
 
-class RawChannelData(object):
-    """ Simple container for raw channel data that's already been read
-    """
-    def __init__(self, data, scaler_data):
-        self.data = data
-        self.scaler_data = scaler_data
-
-
 def _new_numpy_array(dtype, num_values, memmap_dir=None):
     """Initialise a new numpy array for data
 

--- a/nptdms/daqmx.py
+++ b/nptdms/daqmx.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from nptdms import types
 from nptdms.base_segment import (
-    BaseSegment, BaseSegmentObject, DataChunk, read_interleaved_segment_bytes)
+    BaseSegment, BaseSegmentObject, RawDataChunk, read_interleaved_segment_bytes)
 from nptdms.log import log_manager
 
 
@@ -78,7 +78,7 @@ class DaqmxSegment(BaseSegment):
                         scaler.data_type.nptype.newbyteorder(self.endianness))
                     scaler_data[obj.path][scaler.scale_id] = this_scaler_data
 
-        return DataChunk.scaler_data(scaler_data)
+        return RawDataChunk.scaler_data(scaler_data)
 
 
 class DaqmxSegmentObject(BaseSegmentObject):

--- a/nptdms/reader.py
+++ b/nptdms/reader.py
@@ -4,7 +4,7 @@
 import numpy as np
 from nptdms.utils import Timer, OrderedDict
 from nptdms.tdms_segment import read_segment_metadata
-from nptdms.base_segment import ChannelDataChunk
+from nptdms.base_segment import RawChannelDataChunk
 from nptdms.log import log_manager
 
 log = log_manager.get_logger(__name__)
@@ -75,7 +75,7 @@ class TdmsReader(object):
     def read_raw_data(self):
         """ Read raw data from all segments, chunk by chunk
 
-        :returns: A generator that yields DataChunk objects
+        :returns: A generator that yields RawDataChunk objects
         """
         if self._segments is None:
             raise RuntimeError(
@@ -92,7 +92,7 @@ class TdmsReader(object):
         :param length: Number of values to attempt to read.
             If None, then all values starting from the offset will be read.
             Fewer values will be returned if attempting to read beyond the end of the available data.
-        :returns: A generator that yields ChannelDataChunk objects
+        :returns: A generator that yields RawChannelDataChunk objects
         """
         if self._segments is None:
             raise RuntimeError("Cannot read data unless metadata has first been read")
@@ -262,12 +262,12 @@ class ObjectMetadata(object):
 def _trim_channel_chunk(chunk, skip=0, trim=0):
     if skip == 0 and trim == 0:
         return chunk
-    raw_data = None
-    daqmx_raw_data = None
-    if chunk.raw_data is not None:
-        raw_data = chunk.raw_data[skip:len(chunk.raw_data) - trim]
-    if chunk.daqmx_raw_data is not None:
-        daqmx_raw_data = {
+    data = None
+    scaler_data = None
+    if chunk.data is not None:
+        data = chunk.data[skip:len(chunk.data) - trim]
+    if chunk.scaler_data is not None:
+        scaler_data = {
             scale_id: d[skip:len(d) - trim]
-            for (scale_id, d) in chunk.daqmx_raw_data.items()}
-    return ChannelDataChunk(raw_data, daqmx_raw_data)
+            for (scale_id, d) in chunk.scaler_data.items()}
+    return RawChannelDataChunk(data, scaler_data)

--- a/nptdms/scaling.py
+++ b/nptdms/scaling.py
@@ -61,6 +61,8 @@ class PolynomialScaling(object):
         return PolynomialScaling(coefficients, input_source)
 
     def scale(self, data):
+        # Ensure data is double type before scaling
+        data = data.astype(np.dtype('float64'), copy=False)
         return np.polynomial.polynomial.polyval(data, self.coefficients)
 
 
@@ -229,7 +231,7 @@ class ThermistorScaling(object):
         """ Convert voltage data to temperature in Kelvin
         """
         # Ensure data is double precision
-        data = data.astype(np.float64, copy=False)
+        data = data.astype(np.dtype('float64'), copy=False)
         if self.excitation_type == CURRENT_EXCITATION:
             r_t = data / self.excitation_value
         elif self.excitation_type == VOLTAGE_EXCITATION:
@@ -375,6 +377,26 @@ class MultiScaling(object):
     def scale(self, raw_channel_data):
         final_scale = len(self.scalings) - 1
         return self._compute_scaled_data(final_scale, raw_channel_data)
+
+    def get_dtype(self, raw_data_type, scaler_data_types):
+        """ Get the numpy dtype for scaled data
+        """
+        final_scale = len(self.scalings) - 1
+        return self._compute_scale_dtype(final_scale, raw_data_type, scaler_data_types)
+
+    def _compute_scale_dtype(self, scale_index, raw_data_type, scaler_data_types):
+        if scale_index == RAW_DATA_INPUT_SOURCE:
+            return raw_data_type.nptype
+        scaling = self.scalings[scale_index]
+        if scaling is DaqMxScalerScaling:
+            return scaler_data_types[scaling.input_source].nptype
+        elif scaling is AddScaling or scaling is SubtractScaling:
+            return np.result_type(
+                self._compute_scale_dtype(scaling.left_input_source, raw_data_type, scaler_data_types),
+                self._compute_scale_dtype(scaling.right_input_source, raw_data_type, scaler_data_types))
+        else:
+            # Any other scaling type should produce double data
+            return np.dtype('float64')
 
     def _compute_scaled_data(self, scale_index, raw_channel_data):
         """ Compute output data from a single scale in the set of all scalings,

--- a/nptdms/scaling.py
+++ b/nptdms/scaling.py
@@ -388,9 +388,9 @@ class MultiScaling(object):
         if scale_index == RAW_DATA_INPUT_SOURCE:
             return raw_data_type.nptype
         scaling = self.scalings[scale_index]
-        if scaling is DaqMxScalerScaling:
-            return scaler_data_types[scaling.input_source].nptype
-        elif scaling is AddScaling or scaling is SubtractScaling:
+        if isinstance(scaling, DaqMxScalerScaling):
+            return scaler_data_types[scaling.scale_id].nptype
+        elif isinstance(scaling, AddScaling) or isinstance(scaling, SubtractScaling):
             return np.result_type(
                 self._compute_scale_dtype(scaling.left_input_source, raw_data_type, scaler_data_types),
                 self._compute_scale_dtype(scaling.right_input_source, raw_data_type, scaler_data_types))

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -3,6 +3,7 @@
     This module contains the public facing API for reading TDMS files
 """
 
+from collections import defaultdict
 import warnings
 import numpy as np
 
@@ -11,7 +12,7 @@ from nptdms.utils import Timer, OrderedDict
 from nptdms.log import log_manager
 from nptdms.common import ObjectPath
 from nptdms.reader import TdmsReader
-from nptdms.channel_data import get_data_receiver
+from nptdms.channel_data import get_data_receiver, RawChannelData
 from nptdms.export import hdf_export, pandas_export
 
 
@@ -143,6 +144,24 @@ class TdmsFile(object):
         :param group: A group in the HDF5 file that will contain the TDMS data.
         """
         return hdf_export.from_tdms_file(self, filepath, mode, group)
+
+    def data_chunks(self):
+        """ A generator that streams chunks of data from disk.
+        This method may only be used when the TDMS file was opened without reading all data immediately.
+
+        :rtype: Generator that yields :class:`DataChunk` objects
+        """
+        if self._reader is None:
+            raise RuntimeError(
+                "Cannot read data chunks after the underlying TDMS reader is closed")
+        channel_offsets = defaultdict(int)
+        for chunk in self._reader.read_raw_data():
+            yield DataChunk(self, chunk, channel_offsets)
+            for path, data in chunk.raw_data.items():
+                channel_offsets[path] += len(data)
+            for path, data in chunk.daqmx_raw_data.items():
+                first_scaler_data = next(d for d in data.values())
+                channel_offsets[path] += len(first_scaler_data)
 
     def close(self):
         """ Close the underlying file if it was opened by this TdmsFile
@@ -498,7 +517,7 @@ class TdmsChannel(object):
             raise RuntimeError("Channel data has not been read")
 
         if self._raw_data is None:
-            return np.empty((0, 1))
+            return np.empty((0, ))
         if self._data_scaled is None:
             self._data_scaled = self._scale_data(self._raw_data)
         return self._data_scaled
@@ -513,7 +532,7 @@ class TdmsChannel(object):
             raise RuntimeError("Channel data has not been read")
 
         if self._raw_data is None:
-            return np.empty((0, 1))
+            return np.empty((0, ))
         if self._raw_data.scaler_data:
             if len(self._raw_data.scaler_data) == 1:
                 return next(v for v in self._raw_data.scaler_data.values())
@@ -691,6 +710,109 @@ class TdmsChannel(object):
         """(Deprecated)"""
         _deprecated("TdmsChannel.number_values", "Use len(channel)")
         return self._length
+
+
+class DataChunk(object):
+    """ A chunk of data in a TDMS file
+
+    Can be indexed by group name to get the data for a group in this channel,
+    which can then be indexed by channel name to get the data for a channel in this chunk.
+    """
+    def __init__(self, tdms_file, raw_data_chunk, channel_offsets):
+        self._groups = OrderedDict(
+            (group.name, GroupDataChunk(tdms_file, group, raw_data_chunk, channel_offsets))
+            for group in tdms_file.groups())
+
+    def __getitem__(self, group_name):
+        return self._groups[group_name]
+
+    def groups(self):
+        """ Returns chunks of data for a group
+
+        :rtype: List of :class:`GroupDataChunk`
+        """
+        return list(self._groups.values())
+
+
+class GroupDataChunk(object):
+    """ A chunk of data for a group in a TDMS file
+
+    Can be indexed by channel name to get the data for a channel in this chunk.
+
+    :ivar ~.name: Name of the group
+    """
+    def __init__(self, tdms_file, group, raw_data_chunk, channel_offsets):
+        self.name = group.name
+        self._channels = OrderedDict(
+            (channel.name, ChannelDataChunk(tdms_file, channel, raw_data_chunk, channel_offsets[channel.path]))
+            for channel in group.channels())
+
+    def __getitem__(self, channel_name):
+        return self._channels[channel_name]
+
+    def channels(self):
+        """ Returns chunks of channel data
+
+        :rtype: List of :class:`ChannelDataChunk`
+        """
+        return list(self._channels.values())
+
+
+class ChannelDataChunk(object):
+    """ A chunk of data for a channel in a TDMS file
+
+    Is an array-like object that supports indexing to access data, for example::
+
+        chunk_length = len(channel_data_chunk)
+        chunk_data = channel_data_chunk[:]
+
+    :ivar ~.name: Name of the channel
+    :ivar ~.offset: Starting index of this chunk of data in the entire channel
+    """
+    def __init__(self, tdms_file, channel, raw_data_chunk, offset):
+        self._path = ObjectPath.from_string(channel.path)
+        self._tdms_file = tdms_file
+        self._channel = channel
+        self.name = channel.name
+        self.offset = offset
+        try:
+            raw_data = raw_data_chunk.raw_data[channel.path]
+        except KeyError:
+            raw_data = None
+        try:
+            daqmx_raw_data = raw_data_chunk.daqmx_raw_data[channel.path]
+        except KeyError:
+            daqmx_raw_data = None
+        self._raw_data = RawChannelData(raw_data, daqmx_raw_data)
+        self._scaled_data = None
+
+    def __len__(self):
+        return len(self._data())
+
+    def __getitem__(self, index):
+        return self._data()[index]
+
+    def _data(self):
+        if self._scaled_data is not None:
+            return self._scaled_data
+        if self._raw_data.data is None and self._raw_data.scaler_data is None:
+            return np.empty((0, ))
+
+        scale = self._get_scaling()
+        if scale is not None:
+            self._scaled_data = scale.scale(self._raw_data)
+        elif self._raw_data.scaler_data:
+            raise ValueError("Missing scaling information for DAQmx data")
+        else:
+            self._scaled_data = self._raw_data.data
+        return self._scaled_data
+
+    def _get_scaling(self):
+        file_properties = self._tdms_file.properties
+        group_properties = self._tdms_file[self._path.group].properties
+        channel_properties = self._channel.properties
+        return scaling.get_scaling(
+            channel_properties, group_properties, file_properties)
 
 
 class RootObject(object):

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -791,7 +791,7 @@ class ChannelDataChunk(object):
     :ivar ~.offset: Starting index of this chunk of data in the entire channel
     """
     def __init__(self, tdms_file, channel, raw_data_chunk, offset):
-        self._path = ObjectPath.from_string(channel.path)
+        self._path = channel._path
         self._tdms_file = tdms_file
         self._channel = channel
         self.name = channel.name

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -735,6 +735,10 @@ class DataChunk(object):
 
     Can be indexed by group name to get the data for a group in this channel,
     which can then be indexed by channel name to get the data for a channel in this chunk.
+    For example::
+
+        group_chunk = data_chunk[group_name]
+        channel_chunk = group_chunk[channel_name]
     """
     def __init__(self, tdms_file, raw_data_chunk, channel_offsets):
         self._groups = OrderedDict(
@@ -756,6 +760,9 @@ class GroupDataChunk(object):
     """ A chunk of data for a group in a TDMS file
 
     Can be indexed by channel name to get the data for a channel in this chunk.
+    For example::
+
+        channel_chunk = group_chunk[channel_name]
 
     :ivar ~.name: Name of the group
     """
@@ -804,6 +811,9 @@ class ChannelDataChunk(object):
 
     def __getitem__(self, index):
         return self._data()[index]
+
+    def __iter__(self):
+        return iter(self._data())
 
     def _data(self):
         if self._scaled_data is not None:

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -7,7 +7,7 @@ from nptdms.common import toc_properties
 from nptdms.base_segment import (
     BaseSegment,
     BaseSegmentObject,
-    ChannelDataChunk,
+    RawChannelDataChunk,
     RawDataChunk,
     read_interleaved_segment_bytes,
     fromfile)
@@ -194,11 +194,11 @@ class ContiguousDataSegment(BaseSegment):
     def _read_channel_data_chunk(self, file, data_objects, chunk_index, channel_path):
         """ Read data from a chunk for a single channel
         """
-        channel_data = ChannelDataChunk.empty()
+        channel_data = RawChannelDataChunk.empty()
         for obj in data_objects:
             number_values = self._get_channel_number_values(obj, chunk_index)
             if obj.path == channel_path:
-                channel_data = ChannelDataChunk.channel_data(obj.read_values(file, number_values))
+                channel_data = RawChannelDataChunk.channel_data(obj.read_values(file, number_values))
             elif number_values == obj.number_values:
                 # Seek over data for other channel data
                 file.seek(obj.data_size, os.SEEK_CUR)

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -8,7 +8,7 @@ from nptdms.base_segment import (
     BaseSegment,
     BaseSegmentObject,
     ChannelDataChunk,
-    DataChunk,
+    RawDataChunk,
     read_interleaved_segment_bytes,
     fromfile)
 from nptdms.daqmx import DaqmxSegment
@@ -152,7 +152,7 @@ class InterleavedDataSegment(BaseSegment):
             channel_data[obj.path] = object_data
             data_pos += obj.data_type.size
 
-        return DataChunk.channel_data(channel_data)
+        return RawDataChunk.channel_data(channel_data)
 
     def _read_interleaved(self, file, data_objects):
         """Read interleaved data that doesn't have a numpy type"""
@@ -171,7 +171,7 @@ class InterleavedDataSegment(BaseSegment):
                         obj.read_value(file))
                     points_added[obj.path] += 1
 
-        return DataChunk.channel_data(object_data)
+        return RawDataChunk.channel_data(object_data)
 
 
 class ContiguousDataSegment(BaseSegment):
@@ -189,7 +189,7 @@ class ContiguousDataSegment(BaseSegment):
         for obj in data_objects:
             number_values = self._get_channel_number_values(obj, chunk_index)
             object_data[obj.path] = obj.read_values(file, number_values)
-        return DataChunk.channel_data(object_data)
+        return RawDataChunk.channel_data(object_data)
 
     def _read_channel_data_chunk(self, file, data_objects, chunk_index, channel_path):
         """ Read data from a chunk for a single channel

--- a/nptdms/tdmsinfo.py
+++ b/nptdms/tdmsinfo.py
@@ -45,8 +45,7 @@ def tdmsinfo(file, show_properties=False):
             if show_properties:
                 level = 3
                 if channel.data_type is not None:
-                    display("data type: %s" % channel.data_type.__name__,
-                            level)
+                    display("data type: %s" % channel.data_type.__name__, level)
                 display_properties(channel, level)
 
 

--- a/nptdms/test/test_hdf.py
+++ b/nptdms/test/test_hdf.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     pytest.skip("Skipping HDF tests as h5py is not installed", allow_module_level=True)
 
+from nptdms import TdmsFile
 from nptdms.test.util import (
     GeneratedFile,
     basic_segment,
@@ -31,6 +32,22 @@ def test_hdf_channel_data(tmp_path):
     for ((group, channel), expected_data) in expected_data.items():
         h5_channel = h5[group][channel]
         assert h5_channel.dtype.kind == 'i'
+        np.testing.assert_almost_equal(h5_channel[...], expected_data)
+    h5.close()
+
+
+def test_streaming_to_hdf(tmp_path):
+    """ Test conversion of channel data to HDF when streaming data from disk
+    """
+    test_file, expected_data = scenarios.chunked_segment().values
+
+    with test_file.get_tempfile() as temp_file:
+        with TdmsFile.open(temp_file.file) as tdms_file:
+            h5_path = tmp_path / 'h5_streaming_data_test.h5'
+            h5 = tdms_file.as_hdf(h5_path)
+
+    for ((group, channel), expected_data) in expected_data.items():
+        h5_channel = h5[group][channel]
         np.testing.assert_almost_equal(h5_channel[...], expected_data)
     h5.close()
 

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -323,9 +323,10 @@ def test_string_data():
     test_file.add_segment(toc, metadata, data)
     tdms_data = test_file.load()
 
-    data = tdms_data["Group"]["StringChannel"].data
-    assert len(data) == len(strings)
-    for expected, read in zip(strings, data):
+    channel = tdms_data["Group"]["StringChannel"]
+    assert len(channel.data) == len(strings)
+    assert channel.data.dtype == channel.dtype
+    for expected, read in zip(strings, channel.data):
         assert expected == read
 
 

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -157,7 +157,7 @@ def test_stream_data_chunks(test_file, expected_data):
         compare_arrays(actual_data, expected_data)
 
 
-def test_indexing_into_data_chunks():
+def test_indexing_and_iterating_data_chunks():
     """Test streaming chunks of data from a TDMS file and indexing into chunks
     """
     test_file, expected_data = scenarios.single_segment_with_two_channels().values
@@ -168,7 +168,7 @@ def test_indexing_into_data_chunks():
                 for (group, channel) in expected_data.keys():
                     key = (group, channel)
                     channel_chunk = chunk[group][channel]
-                    data_arrays[key].extend(channel_chunk[:])
+                    data_arrays[key].extend(list(channel_chunk))
 
     for ((group, channel), expected_data) in expected_data.items():
         actual_data = data_arrays[(group, channel)]

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -28,8 +28,10 @@ def test_read_channel_data(test_file, expected_data):
         tdms_data = TdmsFile.read(temp_file.file)
 
     for ((group, channel), expected_data) in expected_data.items():
-        actual_data = tdms_data[group][channel].data
+        channel_obj = tdms_data[group][channel]
+        actual_data = channel_obj.data
         assert actual_data.dtype == expected_data.dtype
+        assert channel_obj.dtype == expected_data.dtype
         compare_arrays(actual_data, expected_data)
 
 

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -157,6 +157,24 @@ def test_stream_data_chunks(test_file, expected_data):
         compare_arrays(actual_data, expected_data)
 
 
+def test_indexing_into_data_chunks():
+    """Test streaming chunks of data from a TDMS file and indexing into chunks
+    """
+    test_file, expected_data = scenarios.single_segment_with_two_channels().values
+    data_arrays = defaultdict(list)
+    with test_file.get_tempfile() as temp_file:
+        with TdmsFile.open(temp_file.file) as tdms_file:
+            for chunk in tdms_file.data_chunks():
+                for (group, channel) in expected_data.keys():
+                    key = (group, channel)
+                    channel_chunk = chunk[group][channel]
+                    data_arrays[key].extend(channel_chunk[:])
+
+    for ((group, channel), expected_data) in expected_data.items():
+        actual_data = data_arrays[(group, channel)]
+        compare_arrays(actual_data, expected_data)
+
+
 def test_invalid_offset_throws():
     """ Exception is thrown when reading a subset of data with an invalid offset
     """


### PR DESCRIPTION
When opening a TDMS file with `TdmsFile.read`, support reading chunks of data. Also use this to support streaming export to HDF. Fixes #150 and #164.

In order to support initialising HDF arrays before data is read, adds a `dtype` attribute to `TdmsChannel`.