### PR TITLE
Implement indexing into channels

### DIFF
--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -515,6 +515,18 @@ class TdmsChannel(object):
         else:
             return self._read_data_values()
 
+    def __getitem__(self, index):
+        if self._raw_data is not None:
+            return self.data[index]
+        elif index is Ellipsis:
+            return self.read_data()
+        elif isinstance(index, slice):
+            return self._read_slice(index.start, index.stop, index.step)
+        elif isinstance(index, int):
+            return self._read_at_index(index)
+        else:
+            raise TypeError("Invalid index type '%s', expected int, slice or Ellipsis" % type(index).__name__)
+
     @_property_builtin
     def path(self):
         """ Path to the TDMS object for this channel
@@ -702,6 +714,55 @@ class TdmsChannel(object):
         for chunk in self.data_chunks():
             for value in chunk:
                 yield value
+
+    def _read_slice(self, start, stop, step):
+        if step == 0:
+            raise ValueError("Step size cannot be zero")
+
+        # Replace None values with defaults
+        step = 1 if step is None else step
+        if start is None:
+            start = 0 if step > 0 else -1
+        if stop is None:
+            stop = self._length if step > 0 else -1 - self._length
+
+        # Handle negative indices
+        if start < 0:
+            start = self._length + start
+        if stop < 0:
+            stop = self._length + stop
+
+        # Check for empty ranges
+        if stop == start:
+            return np.empty((0, ), dtype=self.dtype)
+        if step > 0 and (stop < start or start >= self._length or stop < 0):
+            return np.empty((0,), dtype=self.dtype)
+        if step < 0 and (stop > start or stop >= self._length or start < 0):
+            return np.empty((0,), dtype=self.dtype)
+
+        # Trim values outside bounds
+        if start < 0:
+            start = 0
+        if start >= self._length:
+            start = self._length - 1
+        if stop > self._length:
+            stop = self._length
+        if stop < -1:
+            stop = -1
+
+        # Read data and handle step size
+        if step > 0:
+            read_data = self.read_data(start, stop - start)
+            return read_data[::step] if step > 1 else read_data
+        else:
+            read_data = self.read_data(stop + 1, start - stop)
+            return read_data[::step]
+
+    def _read_at_index(self, index):
+        if index < 0 or index >= self._length:
+            raise IndexError("Index {0} is outside of the channel bounds [0, {1}]".format(index, self._length - 1))
+        # TODO: Cache chunk containing the read index
+        return self.read_data(index, 1)[0]
 
     def _scale_data(self, raw_data):
         scale = self._get_scaling()

--- a/nptdms/test/scenarios.py
+++ b/nptdms/test/scenarios.py
@@ -372,22 +372,22 @@ def chunked_segment():
             channel_metadata("/'group'/'channel1'", TDS_TYPE_INT32, 2),
             channel_metadata("/'group'/'channel2'", TDS_TYPE_INT32, 2),
         ),
-        "01 00 00 00" "02 00 00 00"
-        "03 00 00 00" "04 00 00 00"
-        "05 00 00 00" "06 00 00 00"
-        "07 00 00 00" "08 00 00 00"
+        "00 00 00 00" "01 00 00 00"
+        "0A 00 00 00" "0B 00 00 00"
+        "02 00 00 00" "03 00 00 00"
+        "0C 00 00 00" "0D 00 00 00"
     )
     test_file.add_segment(
         ("kTocRawData", ),
         "",
-        "07 00 00 00" "08 00 00 00"
-        "05 00 00 00" "06 00 00 00"
-        "03 00 00 00" "04 00 00 00"
-        "01 00 00 00" "02 00 00 00"
+        "04 00 00 00" "05 00 00 00"
+        "0E 00 00 00" "0F 00 00 00"
+        "06 00 00 00" "07 00 00 00"
+        "10 00 00 00" "11 00 00 00"
     )
     expected_data = {
-        ('group', 'channel1'): np.array([1, 2, 5, 6, 7, 8, 3, 4], dtype=np.int32),
-        ('group', 'channel2'): np.array([3, 4, 7, 8, 5, 6, 1, 2], dtype=np.int32),
+        ('group', 'channel1'): np.array([0, 1, 2, 3, 4, 5, 6, 7], dtype=np.int32),
+        ('group', 'channel2'): np.array([10, 11, 12, 13, 14, 15, 16, 17], dtype=np.int32),
     }
     return test_file, expected_data
 

--- a/nptdms/test/scenarios.py
+++ b/nptdms/test/scenarios.py
@@ -639,10 +639,10 @@ def scaled_data():
         segment_objects_metadata(
             channel_metadata("/'group'/'channel1'", TDS_TYPE_INT32, 2, properties),
         ),
-        "01 00 00 00" "02 00 00 00"
+        "01 00 00 00" "02 00 00 00" "03 00 00 00" "04 00 00 00"
     )
     expected_data = {
-        ('group', 'channel1'): np.array([12, 14], dtype=np.float64),
+        ('group', 'channel1'): np.array([12, 14, 16, 18], dtype=np.float64),
     }
     return test_file, expected_data
 

--- a/nptdms/test/test_pandas.py
+++ b/nptdms/test/test_pandas.py
@@ -267,7 +267,7 @@ def test_channel_as_dataframe_with_raw_data():
     """Convert channel to Pandas dataframe with absolute time index"""
 
     test_file, _ = scenarios.scaled_data().values
-    expected_raw_data = np.array([1, 2], dtype=np.int32)
+    expected_raw_data = np.array([1, 2, 3, 4], dtype=np.int32)
     tdms_data = test_file.load()
 
     df = tdms_data["group"]["channel1"].as_dataframe(scaled_data=False)

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -257,6 +257,34 @@ def test_indexing_channel_with_integer(index):
                 assert channel_object[index] == expected_channel_data[index]
 
 
+def test_indexing_channel_with_integer_and_caching():
+    """ Test indexing into a channel with an integer index, reusing the same file to test caching
+    """
+    test_file, expected_data = scenarios.chunked_segment().values
+    with test_file.get_tempfile() as temp_file:
+        with TdmsFile.open(temp_file.file) as tdms_file:
+            for ((group, channel), expected_channel_data) in expected_data.items():
+                channel_object = tdms_file[group][channel]
+                values = []
+                for i in range(len(channel_object)):
+                    values.append(channel_object[i])
+                compare_arrays(values, expected_channel_data)
+
+
+def test_indexing_scaled_channel_with_integer():
+    """ Test indexing into a channel with an integer index when the channel is scaled
+    """
+    test_file, expected_data = scenarios.scaled_data().values
+    with test_file.get_tempfile() as temp_file:
+        with TdmsFile.open(temp_file.file) as tdms_file:
+            for ((group, channel), expected_channel_data) in expected_data.items():
+                channel_object = tdms_file[group][channel]
+                values = []
+                for i in range(len(channel_object)):
+                    values.append(channel_object[i])
+                compare_arrays(values, expected_channel_data)
+
+
 def test_indexing_channel_with_ellipsis():
     """ Test indexing into a channel with ellipsis returns all data
     """


### PR DESCRIPTION
To allow consistent access to channel data whether a file was read with `TdmsFile.read` or `TdmsFile.open`

For accessing the whole channel data, the recommended  approach will now be (will need documentation updates):
```
tdms_file[group_name][channel_name][:]
```