### PR TITLE
Documentation updates for recent API changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,31 +14,47 @@ npTDMS
 
 npTDMS is a cross-platform Python package for reading and writing TDMS files as produced by LabVIEW,
 and is built on top of the `numpy <http://www.numpy.org/>`__ package.
-Data read from a TDMS file is stored in numpy arrays,
-and numpy arrays are also used when writing TDMS file.
+Data is read from TDMS files as numpy arrays,
+and npTDMS also allows writing numpy arrays to TDMS files.
 
-TDMS files can contain multiple data channels organised intro groups.
+TDMS files are structured in a hierarchy of groups and channels.
+A TDMS file can contain multiple groups, which may each contain multiple channels.
+A file, group and channel may all have properties associated with them,
+but only channels have array data.
+
 Typical usage when reading a TDMS file might look like::
 
     from nptdms import TdmsFile
 
     tdms_file = TdmsFile.read("path_to_file.tdms")
-    channel = tdms_file['Group']['Channel1']
-    data = channel.data
-    time = channel.time_track()
-    # do stuff with data
+    group = tdms_file['group name']
+    channel = group['channel name']
+    channel_data = channel[:]
+    channel_properties = channel.properties
 
-And to write a file::
+The ``TdmsFile.read`` method reads all data into memory immediately.
+When you are working with large TDMS files or don't need to read all channel data,
+you can instead use ``TdmsFile.open``. This is more memory efficient but
+accessing data can be slower::
+
+    with TdmsFile.open("path_to_file.tdms"):
+        group = tdms_file['group name']
+        channel = group['channel name']
+        channel_data = channel[:]
+
+npTDMS also has rudimentary support for writing TDMS files.
+Using npTDMS to write a TDMS file looks like::
 
     from nptdms import TdmsWriter, ChannelObject
     import numpy
 
     with TdmsWriter("path_to_file.tdms") as tdms_writer:
         data_array = numpy.linspace(0, 1, 10)
-        channel = ChannelObject('Group', 'Channel1', data_array)
+        channel = ChannelObject('group name', 'channel name', data_array)
         tdms_writer.write_segment([channel])
 
-For more information, see the `npTDMS documentation <http://nptdms.readthedocs.io>`__.
+For more detailed documentation on reading and writing TDMS files,
+see the `npTDMS documentation <http://nptdms.readthedocs.io>`__.
 
 Installation
 ------------
@@ -72,7 +88,7 @@ Limitations
 -----------
 
 This module doesn't support TDMS files with XML headers or with
-extended floating point data.
+extended precision floating point data.
 
 TDMS files support timestamps with a resolution of 2^-64 seconds but these
 are read as numpy datetime64 values with microsecond resolution.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,8 @@ Welcome to npTDMS's documentation
 
 npTDMS is a cross-platform Python package for reading and writing TDMS files as produced by LabVIEW,
 and is built on top of the `numpy <http://www.numpy.org/>`__ package.
-Data read from a TDMS file is stored in numpy arrays,
-and numpy arrays are also used when writing TDMS file.
+Data is read from TDMS files as numpy arrays,
+and npTDMS also allows writing numpy arrays to TDMS files.
 
 Contents
 ========

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -1,5 +1,5 @@
 Limitations
 ===========
 
-npTDMS currently doesn't support reading TDMS files with XML headers,
-or files with extended floating point data.
+npTDMS currently doesn't support reading TDMS files with XML headers (TDM files),
+or files with extended precision floating point data.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -28,14 +28,26 @@ Typical usage when reading a TDMS file might look like::
             # Access dictionary of properties:
             properties = channel.properties
             # Access numpy array of data for channel:
-            data = channel.data
-            # do stuff with data and properties...
+            data = channel[:]
+            # Access a subset of data
+            data_subset = channel[100:200]
 
 Or to access a channel by group name and channel name directly::
 
-    channel = tdms_file[group_name][channel_name]
+    group = tdms_file[group_name]
+    channel = group[channel_name]
 
-And to write a TDMS file::
+The ``TdmsFile.read`` method reads all data into memory immediately.
+When you are working with large TDMS files or don't need to read all channel data,
+you can instead use ``TdmsFile.open``. This is more memory efficient but
+accessing data can be slower::
+
+    with TdmsFile.open("path_to_file.tdms"):
+        channel = tdms_file['group name']['channel name']
+        channel_data = channel[:]
+
+npTDMS also has rudimentary support for writing TDMS files.
+Using npTDMS to write a TDMS file looks like::
 
     from nptdms import TdmsWriter, ChannelObject
     import numpy

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -43,7 +43,7 @@ you can instead use ``TdmsFile.open``. This is more memory efficient but
 accessing data can be slower::
 
     with TdmsFile.open("path_to_file.tdms"):
-        channel = tdms_file['group name']['channel name']
+        channel = tdms_file[group_name][channel_name]
         channel_data = channel[:]
 
 npTDMS also has rudimentary support for writing TDMS files.

--- a/docs/reading.rst
+++ b/docs/reading.rst
@@ -2,15 +2,15 @@ Reading TDMS files
 ==================
 
 To read a TDMS file, create an instance of the :py:class:`~nptdms.TdmsFile`
-class using one of the static :py:meth:`~nptdms.TdmsFile.read` or :py:meth:`~nptdms.TdmsFile.open` methods,
+class using one of the static :py:meth:`nptdms.TdmsFile.read` or :py:meth:`nptdms.TdmsFile.open` methods,
 passing the path to the file, or an already opened file.
-The :py:meth:`~nptdms.TdmsFile.read` method will read all channel data immediately,
-whereas the :py:meth:`~nptdms.TdmsFile.open` method will only read the file metadata,
-keeping the file open to allow channel data to be read on demand::
+The :py:meth:`~nptdms.TdmsFile.read` method will read all channel data immediately::
 
     tdms_file = TdmsFile.read("my_file.tdms")
 
-or::
+If using the :py:meth:`~nptdms.TdmsFile.open` method, only the file metadata will be read initially,
+and the returned :py:class:`~nptdms.TdmsFile` object should be used as a context manager to keep
+the file open and allow channel data to be read on demand::
 
     with TdmsFile.open("my_file.tdms") as tdms_file:
         # Use tdms_file
@@ -83,7 +83,7 @@ TDMS files are written in multiple segments, where each segment can in turn have
 multiple chunks of data.
 When accessing a value or a slice of data in a channel, npTDMS will read whole chunks at a time.
 npTDMS also allows streaming data from a file chunk by chunk using
-:py:meth:`~nptdms.TdmsFile.data_chunks`. This is a generator that produces instances of
+:py:meth:`nptdms.TdmsFile.data_chunks`. This is a generator that produces instances of
 :py:class:`~nptdms.DataChunk`.
 For example, to compute the mean of a channel::
 
@@ -97,7 +97,7 @@ For example, to compute the mean of a channel::
     channel_mean = channel_sum / channel_length
 
 This approach can be useful to stream TDMS data to another format on disk or into a data store.
-It's also possible to stream data chunks for a single channel using :py:meth:`~nptdms.TdmsChannel.data_chunks`::
+It's also possible to stream data chunks for a single channel using :py:meth:`nptdms.TdmsChannel.data_chunks`::
 
     with TdmsFile.open(tdms_file_path) as tdms_file:
         channel = tdms_file[group_name][channel_name]

--- a/docs/writing.rst
+++ b/docs/writing.rst
@@ -39,7 +39,7 @@ The data types supported as property values are:
 - Integers
 - Floating point values
 - Strings
-- datetime objects
+- datetime or numpy datetime64 objects
 - Boolean values
 
 For more control over the data type used to represent a property value, for example

--- a/docs/writing.rst
+++ b/docs/writing.rst
@@ -31,7 +31,7 @@ instance of one of:
 - :py:class:`nptdms.TdmsGroup` or :py:class:`nptdms.TdmsChannel`.
   A TDMS object that was read from a TDMS file using :py:class:`nptdms.TdmsFile`.
 
-Each of ``RootObject``, ``GroupObject`` and ``ChannelObject``
+Each of :py:class:`~nptdms.RootObject`, :py:class:`~nptdms.GroupObject` and :py:class:`~nptdms.ChannelObject`
 may optionally have properties associated with them, which
 are passed into the ``__init__`` method as a dictionary.
 The data types supported as property values are:
@@ -63,10 +63,15 @@ is given below::
     channel_object = ChannelObject("group_1", "channel_1", data, properties={})
 
     with TdmsWriter("my_file.tdms") as tdms_writer:
+        # Write first segment
         tdms_writer.write_segment([
             root_object,
             group_object,
             channel_object])
+        # Write another segment with more data for the same channel
+        more_data = np.array([6.0, 7.0, 8.0, 9.0, 10.0])
+        channel_object = ChannelObject("group_1", "channel_1", more_data, properties={})
+        tdms_writer.write_segment([channel_object])
 
 You could also read a TDMS file and then re-write it by passing
 :py:class:`~nptdms.TdmsGroup` and :py:class:`~nptdms.TdmsChannel`

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -961,7 +961,7 @@ class GroupDataChunk(object):
         return self._channels[channel_name]
 
     def channels(self):
-        """ Returns chunks of channel data for all channels
+        """ Returns chunks of channel data for all channels in this group
 
         :rtype: List of :class:`ChannelDataChunk`
         """

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -539,7 +539,7 @@ class TdmsChannel(object):
 
         all_data = channel[:]
 
-    Or to retrieve a subset of data:
+    Or to retrieve a subset of data::
 
         data_subset = channel[start:stop]
 
@@ -665,8 +665,6 @@ class TdmsChannel(object):
         """ If the TdmsFile was created by reading all data, this property
         provides direct access to the numpy array of raw DAQmx scaler data
         as a dictionary mapping from scale id to raw data arrays.
-
-        For unscaled objects this is the same as the data property.
         """
         if len(self) > 0 and self._raw_data is None:
             raise RuntimeError("Channel data has not been read")
@@ -930,7 +928,7 @@ class DataChunk(object):
         return self._groups[group_name]
 
     def groups(self):
-        """ Returns chunks of data for a group
+        """ Returns chunks of data for all groups
 
         :rtype: List of :class:`GroupDataChunk`
         """
@@ -963,7 +961,7 @@ class GroupDataChunk(object):
         return self._channels[channel_name]
 
     def channels(self):
-        """ Returns chunks of channel data
+        """ Returns chunks of channel data for all channels
 
         :rtype: List of :class:`ChannelDataChunk`
         """

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -28,10 +28,32 @@ _property_builtin = property
 class TdmsFile(object):
     """ Reads and stores data from a TDMS file.
 
-    Can be indexed by group name to access a group within the TDMS file, for example::
+    There are two main ways to create a new TdmsFile object.
+    TdmsFile.read will read all data into memory::
+
+        tdms_file = TdmsFile.read(tdms_file_path)
+
+    or you can use TdmsFile.open to read file metadata but not immediately read all data,
+    for cases where a file is too large to easily fit in memory or you don't need to
+    read data for all channels::
+
+        with TdmsFile.open(tdms_file_path) as tdms_file:
+            # Use tdms_file
+            ...
+
+    This class acts like a dictionary, where the keys are names of groups in the TDMS
+    files and the values are TdmsGroup objects.
+    A TdmsFile can be indexed by group name to access a group within the TDMS file, for example::
 
         tdms_file = TdmsFile.read(tdms_file_path)
         group = tdms_file[group_name]
+
+    Iterating over a TdmsFile produces the names of groups in this file,
+    or you can use the groups method to directly access all groups::
+
+        for group in tdms_file.groups():
+            # Use group
+            ...
     """
 
     @staticmethod
@@ -173,6 +195,8 @@ class TdmsFile(object):
             self._reader = None
 
     def __iter__(self):
+        """ Returns an iterator over the names of groups in this file
+        """
         return iter(self._groups)
 
     def __getitem__(self, group_name):
@@ -385,9 +409,18 @@ class TdmsFile(object):
 class TdmsGroup(object):
     """ Represents a group of channels in a TDMS file.
 
-    Can be indexed by channel name to access a channel in this group, for example::
+    This class acts like a dictionary, where the keys are names of channels in the group
+    and the values are TdmsChannel objects.
+    A TdmsGroup can be indexed by channel name to access a channel in this group, for example::
 
         channel = group[channel_name]
+
+    Iterating over a TdmsGroup produces the names of channels in this group,
+    or you can use the channels method to directly access all channels::
+
+        for channel in group.channels():
+            # Use channel
+            ...
 
     :ivar ~.properties: Dictionary of TDMS properties defined for this group.
     """
@@ -436,6 +469,8 @@ class TdmsGroup(object):
         return pandas_export.from_group(self, time_index, absolute_time, scaled_data)
 
     def __iter__(self):
+        """ Returns an iterator over the names of channels in this group
+        """
         return iter(self._channels)
 
     def __getitem__(self, channel_name):
@@ -490,7 +525,23 @@ class TdmsGroup(object):
 class TdmsChannel(object):
     """ Represents a data channel in a TDMS file.
 
-    To find the number of data points in this channel use :code:`len(channel)`.
+    This class acts like an array, you can get the length of a channel using :code:`len(channel)`,
+    and can iterate over values in the channel using a for loop,
+    or index into a channel using an integer index to get a single value::
+
+        for value in channel:
+            # Use value
+            ...
+        first_value = channel[0]
+
+    Or you can index using a slice to retrieve a range of data as a numpy array.
+    To get all data in this channel as a numpy array::
+
+        all_data = channel[:]
+
+    Or to retrieve a subset of data:
+
+        data_subset = channel[start:stop]
 
     :ivar ~.properties: Dictionary of TDMS properties defined for this channel,
                       for example the start time and time increment for waveforms.
@@ -516,9 +567,13 @@ class TdmsChannel(object):
         return "<TdmsChannel with path %s>" % self.path
 
     def __len__(self):
+        """ Returns the number of values in this channel
+        """
         return self._length
 
     def __iter__(self):
+        """ Returns an iterator over the values in this channel
+        """
         if self._raw_data is not None:
             return iter(self.data)
         else:
@@ -568,8 +623,12 @@ class TdmsChannel(object):
 
     @_property_builtin
     def data(self):
-        """
-        NumPy array containing the data for this channel
+        """ If the TdmsFile was created by reading all data, this property
+        provides direct access to the numpy array containing the data for this channel.
+
+        Indexing into the channel with a slice should be preferred to using this property, for example::
+
+            channel_data = channel[:]
         """
         if len(self) > 0 and self._raw_data is None:
             raise RuntimeError("Channel data has not been read")
@@ -582,8 +641,8 @@ class TdmsChannel(object):
 
     @_property_builtin
     def raw_data(self):
-        """
-        The raw, unscaled data array.
+        """ If the TdmsFile was created by reading all data, this property
+        provides direct access to the numpy array of raw, unscaled data.
         For unscaled objects this is the same as the data property.
         """
         if len(self) > 0 and self._raw_data is None:
@@ -603,7 +662,11 @@ class TdmsChannel(object):
 
     @_property_builtin
     def raw_scaler_data(self):
-        """ Raw DAQmx scaler data as a dictionary mapping from scale id to raw data arrays
+        """ If the TdmsFile was created by reading all data, this property
+        provides direct access to the numpy array of raw DAQmx scaler data
+        as a dictionary mapping from scale id to raw data arrays.
+
+        For unscaled objects this is the same as the data property.
         """
         if len(self) > 0 and self._raw_data is None:
             raise RuntimeError("Channel data has not been read")
@@ -622,17 +685,17 @@ class TdmsChannel(object):
             channel_offset += len(raw_data_chunk)
 
     def read_data(self, offset=0, length=None, scaled=True):
-        """ Reads data for this channel from the TDMS file and returns it
+        """ Reads data for this channel from the TDMS file and returns it as a numpy array
 
-            This is for use when the TDMS file was opened without immediately reading all data,
-            otherwise the data attribute should be used.
+        Indexing into the channel with a slice should be preferred over using
+        this method, but this method is needed if you want to read raw, unscaled data.
 
-            :param offset: Initial position to read data from.
-            :param length: Number of values to attempt to read.
-                Fewer values will be returned if attempting to read beyond the end of the available data.
-            :param scaled: By default scaling will be applied to the returned data.
-                Set this parameter to False to return raw unscaled data.
-                For DAQmx data a dictionary of scaler id to raw scaler data will be returned.
+        :param offset: Initial position to read data from.
+        :param length: Number of values to attempt to read.
+            Fewer values will be returned if attempting to read beyond the end of the available data.
+        :param scaled: By default scaling will be applied to the returned data.
+            Set this parameter to False to return raw unscaled data.
+            For DAQmx data a dictionary of scaler id to raw scaler data will be returned.
         """
         raw_data = self._tdms_file._read_channel_data(self, offset, length)
         if scaled:
@@ -835,7 +898,7 @@ class TdmsChannel(object):
 
     @_property_builtin
     def has_data(self):
-        """Deprecated"""
+        """(Deprecated)"""
         _deprecated("TdmsChannel.has_data", "This always returns True")
         return True
 
@@ -862,6 +925,8 @@ class DataChunk(object):
             for group in tdms_file.groups())
 
     def __getitem__(self, group_name):
+        """ Get a chunk of data for a group
+        """
         return self._groups[group_name]
 
     def groups(self):
@@ -893,6 +958,8 @@ class GroupDataChunk(object):
             for channel in group.channels())
 
     def __getitem__(self, channel_name):
+        """ Get a chunk of data for a channel in this group
+        """
         return self._channels[channel_name]
 
     def channels(self):
@@ -924,12 +991,18 @@ class ChannelDataChunk(object):
         self._scaled_data = None
 
     def __len__(self):
+        """ Returns the number of values in this chunk
+        """
         return len(self._raw_data)
 
     def __getitem__(self, index):
+        """ Get a value or slice of values from this chunk
+        """
         return self._data()[index]
 
     def __iter__(self):
+        """ Iterate over values in this chunk
+        """
         return iter(self._data())
 
     def _data(self):


### PR DESCRIPTION
Add more documentation on using the new `TdmsFile.open` method and prefer use of `channel[:]` to access data rather than `channel.data`.