### PR TITLE
Improve performance of reading segment metadata

### DIFF
--- a/nptdms/types.py
+++ b/nptdms/types.py
@@ -189,7 +189,8 @@ class String(TdmsType):
 
     @staticmethod
     def read(file, endianness="<"):
-        size = Uint32.read(file, endianness)
+        size_bytes = file.read(4)
+        size = _struct_unpack(endianness + 'L', size_bytes)[0]
         return file.read(size).decode('utf-8')
 
 


### PR DESCRIPTION
Fix slow lookup of existing objects in the segment copied from the previous segment and avoid this check completely when kTocNewObjList is set.
Also add some micro optimisations to speed things up further.
Reading the metadata of the file from #19 is over 5 times faster with these changes on my machine.