### PR TITLE
Read timestamp data with numpy

### DIFF
--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -1013,14 +1013,13 @@ class ChannelDataChunk(object):
     def __getitem__(self, index):
         """ Get a value or slice of values from this chunk
         """
-        return self._data[index]
+        return self._data()[index]
 
     def __iter__(self):
         """ Iterate over values in this chunk
         """
-        return iter(self._data)
+        return iter(self._data())
 
-    @cached_property
     def _data(self):
         if self._raw_data.data is None and self._raw_data.scaler_data is None:
             return np.empty((0, ), dtype=self._channel.dtype)

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -25,30 +25,29 @@ class InterleavedDataSegment(BaseSegment):
         return TdmsSegmentObject(object_path, self.endianness)
 
     def _read_data_chunk(self, file, data_objects, chunk_index):
-        # If all data types have numpy types and all the lengths are
+        # If all data types are sized and all the lengths are
         # the same, then we can read all data at once with numpy,
         # which is much faster
-        all_numpy = all(
-            o.data_type.nptype is not None for o in data_objects)
+        all_sized = all(
+            o.data_type.size is not None for o in data_objects)
         same_length = (len(
             set((o.number_values for o in data_objects))) == 1)
-        if all_numpy and same_length:
-            return self._read_interleaved_numpy(file, data_objects)
+        if all_sized and same_length:
+            return self._read_interleaved_sized(file, data_objects)
         else:
             return self._read_interleaved(file, data_objects)
 
-    def _read_interleaved_numpy(self, file, data_objects):
-        """Read interleaved data where all channels have a numpy type"""
-
+    def _read_interleaved_sized(self, file, data_objects):
+        """Read interleaved data where all channels have a sized data type and the same length
+        """
         log.debug("Reading interleaved data all at once")
 
-        # For non-DAQmx, simply use the data type sizes
-        all_channel_bytes = sum(o.data_type.size for o in data_objects)
-        log.debug("all_channel_bytes: %d", all_channel_bytes)
+        total_data_width = sum(o.data_type.size for o in data_objects)
+        log.debug("total_data_width: %d", total_data_width)
 
         # Read all data into 1 byte unsigned ints first
         combined_data = read_interleaved_segment_bytes(
-            file, all_channel_bytes, data_objects[0].number_values)
+            file, total_data_width, data_objects[0].number_values)
 
         # Now get arrays for each channel
         channel_data = {}
@@ -61,10 +60,12 @@ class InterleavedDataSegment(BaseSegment):
             # be number of bytes per point * number of data points.
             # Then use ravel to flatten the results into a vector.
             object_data = combined_data[:, byte_columns].ravel()
-            # Now set correct data type, so that the array length should
-            # be correct
-            object_data.dtype = (
-                obj.data_type.nptype.newbyteorder(self.endianness))
+            if obj.data_type.nptype is not None:
+                # Set correct data type, so that the array length should be correct
+                object_data.dtype = (
+                    obj.data_type.nptype.newbyteorder(self.endianness))
+            else:
+                object_data = obj.data_type.from_bytes(object_data, self.endianness)
             channel_data[obj.path] = object_data
             data_pos += obj.data_type.size
 

--- a/nptdms/test/scenarios.py
+++ b/nptdms/test/scenarios.py
@@ -776,7 +776,7 @@ def timestamp_data():
 
     test_file = GeneratedFile()
     toc = ("kTocMetaData", "kTocRawData", "kTocNewObjList")
-    test_file.add_segment(toc, metadata, _timestamp_data(times))
+    test_file.add_segment(toc, metadata, timestamp_data_chunk(times))
 
     expected_data = {
         ('Group', 'TimeChannel1'): np.array([times[0], times[1]]),
@@ -834,7 +834,7 @@ def interleaved_timestamp_data():
 
     test_file = GeneratedFile()
     toc = ("kTocMetaData", "kTocRawData", "kTocNewObjList", "kTocInterleavedData")
-    test_file.add_segment(toc, metadata, _timestamp_data(times))
+    test_file.add_segment(toc, metadata, timestamp_data_chunk(times))
 
     expected_data = {
         ('Group', 'TimeChannel1'): np.array([times[0], times[2]]),
@@ -888,9 +888,9 @@ def interleaved_timestamp_and_numpy_data():
         # Number of properties (0)
         "00 00 00 00")
 
-    data = (_timestamp_data([times[0]]) +
+    data = (timestamp_data_chunk([times[0]]) +
             "01 00 00 00" +
-            _timestamp_data([times[1]]) +
+            timestamp_data_chunk([times[1]]) +
             "02 00 00 00")
 
     test_file = GeneratedFile()
@@ -974,7 +974,7 @@ def channel_without_data_or_data_type():
     return test_file, expected_data
 
 
-def _timestamp_data(times):
+def timestamp_data_chunk(times):
     epoch = np.datetime64('1904-01-01T00:00:00')
 
     def total_seconds(td):

--- a/nptdms/test/test_benchmarks.py
+++ b/nptdms/test/test_benchmarks.py
@@ -11,7 +11,7 @@ from nptdms.test.util import (
     channel_metadata,
     channel_metadata_with_no_data,
     channel_metadata_with_repeated_structure)
-from nptdms.test.scenarios import TDS_TYPE_INT32
+from nptdms.test.scenarios import TDS_TYPE_INT32, timestamp_data_chunk
 
 
 @pytest.mark.benchmark(group='read-all-data')
@@ -173,6 +173,33 @@ def test_stream_scaled_data_chunks(benchmark):
         channel_data = np.concatenate(channel_data)
         expected_data = np.tile(10.0 + 2.0 * data_array, 10)
         np.testing.assert_equal(channel_data, expected_data)
+
+
+@pytest.mark.benchmark(group='read-timestamp-data')
+def test_read_timestamp_data(benchmark):
+    """ Benchmark reading a file with timestamp data
+    """
+    timestamps = np.tile(np.array([
+        np.datetime64('2012-08-23T00:00:00.123', 'us'),
+        np.datetime64('2012-08-23T01:02:03.456', 'us'),
+        np.datetime64('2012-08-23T12:00:00.0', 'us'),
+        np.datetime64('2012-08-23T12:02:03.9999', 'us'),
+        np.datetime64('2012-08-23T12:02:03.9999', 'us'),
+    ]), 200)
+    data = timestamp_data_chunk(timestamps)
+
+    test_file = GeneratedFile()
+    test_file.add_segment(
+        ("kTocMetaData", "kTocRawData", "kTocNewObjList"),
+        segment_objects_metadata(
+            channel_metadata("/'group'/'channel1'", 0x44, 200, {}),
+        ),
+        data
+    )
+
+    tdms_file = benchmark(read_from_start, test_file.get_bytes_io_file())
+
+    np.testing.assert_equal(tdms_file['group']['channel1'][:], timestamps)
 
 
 @pytest.mark.benchmark(group='read-metadata')


### PR DESCRIPTION
Read all timestamp data at once as a numpy array before converting to a timestamp.
Improves speed by >10 times in benchmarks.

Also stop caching scaled data in channel chunks as this adds a lot of overhead.