### PR TITLE
Allow reading timestamps as raw TDMS timestamps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,9 +93,6 @@ Limitations
 This module doesn't support TDMS files with XML headers or with
 extended precision floating point data.
 
-TDMS files support timestamps with a resolution of 2^-64 seconds but these
-are read as numpy datetime64 values with microsecond resolution.
-
 Contributors/Thanks
 -------------------
 

--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -81,6 +81,17 @@ Data Types for Property Values
 
 .. autoclass:: TimeStamp
 
+Timestamps
+----------
+
+.. module:: nptdms.timestamp
+
+.. autoclass:: TdmsTimestamp
+  :members:
+
+.. autoclass:: TimestampArray()
+  :members:
+
 Indices and Tables
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -224,27 +224,4 @@ man_pages = [
 ]
 
 
-# Mock numpy module so that docs will build on readthedocs
-# Based on docs at http://read-the-docs.readthedocs.org/en/latest/faq.html
-class Mock(object):
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def __call__(self, *args, **kwargs):
-        return Mock()
-
-    @classmethod
-    def __getattr__(cls, name):
-        if name in ('__file__', '__path__'):
-            return '/dev/null'
-        elif name[0] == name[0].upper():
-            mockType = type(name, (), {})
-            mockType.__module__ = __name__
-            return mockType
-        else:
-            return Mock()
-
-
-MOCK_MODULES = ['numpy', 'np']
-for mod_name in MOCK_MODULES:
-    sys.modules[mod_name] = Mock()
+autodoc_mock_imports = ['numpy', 'np', 'numpy.polynomial.polynomial']

--- a/docs/reading.rst
+++ b/docs/reading.rst
@@ -139,8 +139,7 @@ accept a ``raw_timestamps`` parameter.
 When this is true, any timestamp properties will be returned as a :py:class:`~nptdms.timestamp.TdmsTimestamp`
 object. This has ``seconds`` and ``second_fractions`` attributes which are the number of seconds
 since the epoch 1904-01-01 00:00:00 UTC, and a positive number of 2\ :sup:`-64` fractions of a second.
-This class has a :py:meth:`~nptdms.timestamp.TdmsTimestamp.as_datetime64` method for converting to a numpy datetime64
-object. For example::
+This class has methods for converting to a numpy datetime64 object or datetime.datetime. For example::
 
     >>> timestamp = channel.properties['wf_start_time']
     >>> timestamp
@@ -153,6 +152,8 @@ object. For example::
     2020-04-22T21:43:16.609444
     >>> timestamp.as_datetime64('ns')
     numpy.datetime64('2020-04-22T21:43:16.609444037')
+    >>> timestamp.as_datetime()
+    datetime.datetime(2020, 4, 22, 21, 43, 16, 609444)
 
 When setting ``raw_timestamps`` to true, channels with timestamp data will return data as a
 :py:class:`~nptdms.timestamp.TimestampArray` rather than as a ``datetime64`` array.

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -284,7 +284,7 @@ class TdmsFile(object):
             for group in self.groups():
                 for channel in group.channels():
                     self._channel_data[channel.path] = get_data_receiver(
-                        channel, len(channel), self._memmap_dir)
+                        channel, len(channel), self._raw_timestamps, self._memmap_dir)
 
         with Timer(log, "Read data"):
             # Now actually read all the data
@@ -327,7 +327,7 @@ class TdmsFile(object):
             else:
                 num_values = min(length, len(channel) - offset)
             num_values = max(0, num_values)
-            channel_data = get_data_receiver(channel, num_values, self._memmap_dir)
+            channel_data = get_data_receiver(channel, num_values, self._raw_timestamps, self._memmap_dir)
 
         with Timer(log, "Read data for channel"):
             # Now actually read all the data

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -57,48 +57,61 @@ class TdmsFile(object):
     """
 
     @staticmethod
-    def read(file, memmap_dir=None):
+    def read(file, raw_timestamps=False, memmap_dir=None):
         """ Creates a new TdmsFile object and reads all data in the file
 
         :param file: Either the path to the tdms file to read
             as a string or pathlib.Path, or an already opened file.
+        :param raw_timestamps: By default TDMS timestamps are read as numpy datetime64
+            but this loses some precision.
+            Setting this to true will read timestamps as a custom TdmsTimestamp type.
         :param memmap_dir: The directory to store memory mapped data files in,
             or None to read data into memory. The data files are created
             as temporary files and are deleted when the channel data is no
             longer used. tempfile.gettempdir() can be used to get the default
             temporary file directory.
         """
-        return TdmsFile(file, memmap_dir=memmap_dir)
+        return TdmsFile(file, raw_timestamps=raw_timestamps, memmap_dir=memmap_dir)
 
     @staticmethod
-    def open(file, memmap_dir=None):
+    def open(file, raw_timestamps=False, memmap_dir=None):
         """ Creates a new TdmsFile object and reads metadata, leaving the file open
             to allow reading channel data
 
         :param file: Either the path to the tdms file to read
             as a string or pathlib.Path, or an already opened file.
+        :param raw_timestamps: By default TDMS timestamps are read as numpy datetime64
+            but this loses some precision.
+            Setting this to true will read timestamps as a custom TdmsTimestamp type.
         :param memmap_dir: The directory to store memory mapped data files in,
             or None to read data into memory. The data files are created
             as temporary files and are deleted when the channel data is no
             longer used. tempfile.gettempdir() can be used to get the default
             temporary file directory.
         """
-        return TdmsFile(file, memmap_dir=memmap_dir, read_metadata_only=True, keep_open=True)
+        return TdmsFile(
+            file, raw_timestamps=raw_timestamps, memmap_dir=memmap_dir, read_metadata_only=True, keep_open=True)
 
     @staticmethod
-    def read_metadata(file):
+    def read_metadata(file, raw_timestamps=False):
         """ Creates a new TdmsFile object and only reads the metadata
 
         :param file: Either the path to the tdms file to read
             as a string or pathlib.Path, or an already opened file.
+        :param raw_timestamps: By default TDMS timestamps are read as numpy datetime64
+            but this loses some precision.
+            Setting this to true will read timestamps as a custom TdmsTimestamp type.
         """
-        return TdmsFile(file, read_metadata_only=True)
+        return TdmsFile(file, raw_timestamps=raw_timestamps, read_metadata_only=True)
 
-    def __init__(self, file, memmap_dir=None, read_metadata_only=False, keep_open=False):
+    def __init__(self, file, raw_timestamps=False, memmap_dir=None, read_metadata_only=False, keep_open=False):
         """Initialise a new TdmsFile object
 
         :param file: Either the path to the tdms file to read
             as a string or pathlib.Path, or an already opened file.
+        :param raw_timestamps: By default TDMS timestamps are read as numpy datetime64
+            but this loses some precision.
+            Setting this to true will read timestamps as a custom TdmsTimestamp type.
         :param memmap_dir: The directory to store memory mapped data files in,
             or None to read data into memory. The data files are created
             as temporary files and are deleted when the channel data is no
@@ -111,6 +124,7 @@ class TdmsFile(object):
         """
 
         self._memmap_dir = memmap_dir
+        self._raw_timestamps = raw_timestamps
         self._groups = OrderedDict()
         self._properties = {}
         self._channel_data = {}

--- a/nptdms/test/scenarios.py
+++ b/nptdms/test/scenarios.py
@@ -740,43 +740,15 @@ def timestamp_data():
         np.datetime64('2012-08-23T12:02:03.9999', 'us'),
     ]
 
-    metadata = (
-        # Number of objects
-        "02 00 00 00"
-        # Length of the object path
-        "17 00 00 00")
-    metadata += string_hexlify("/'Group'/'TimeChannel1'")
-    metadata += (
-        # Length of index information
-        "14 00 00 00"
-        # Raw data data type
-        "44 00 00 00"
-        # Dimension
-        "01 00 00 00"
-        # Number of raw data values
-        "02 00 00 00"
-        "00 00 00 00"
-        # Number of properties (0)
-        "00 00 00 00")
-    metadata += (
-        "17 00 00 00")
-    metadata += string_hexlify("/'Group'/'TimeChannel2'")
-    metadata += (
-        # Length of index information
-        "14 00 00 00"
-        # Raw data data type
-        "44 00 00 00"
-        # Dimension
-        "01 00 00 00"
-        # Number of raw data values
-        "02 00 00 00"
-        "00 00 00 00"
-        # Number of properties (0)
-        "00 00 00 00")
-
     test_file = GeneratedFile()
-    toc = ("kTocMetaData", "kTocRawData", "kTocNewObjList")
-    test_file.add_segment(toc, metadata, timestamp_data_chunk(times))
+    test_file.add_segment(
+        ("kTocMetaData", "kTocRawData", "kTocNewObjList"),
+        segment_objects_metadata(
+            channel_metadata("/'Group'/'TimeChannel1'", 0x44, 2),
+            channel_metadata("/'Group'/'TimeChannel2'", 0x44, 2),
+        ),
+        timestamp_data_chunk(times)
+    )
 
     expected_data = {
         ('Group', 'TimeChannel1'): np.array([times[0], times[1]]),

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -274,6 +274,18 @@ def test_indexing_channel_with_integer_and_caching():
                 compare_arrays(values, expected_channel_data)
 
 
+@given(index=strategies.integers(0, 1))
+def test_indexing_timestamp_channel_with_integer(index):
+    """ Test indexing into a timestamp data channel with an integer index
+    """
+    test_file, expected_data = scenarios.timestamp_data().values
+    with test_file.get_tempfile() as temp_file:
+        with TdmsFile.open(temp_file.file) as tdms_file:
+            for ((group, channel), expected_channel_data) in expected_data.items():
+                channel_object = tdms_file[group][channel]
+                assert channel_object[index] == expected_channel_data[index]
+
+
 def test_indexing_scaled_channel_with_integer():
     """ Test indexing into a channel with an integer index when the channel is scaled
     """

--- a/nptdms/test/test_timestamps.py
+++ b/nptdms/test/test_timestamps.py
@@ -2,7 +2,9 @@
 """
 
 import numpy as np
+import pytest
 from nptdms import TdmsFile
+from nptdms.timestamp import TdmsTimestamp, TimestampArray
 from nptdms.test.util import (
     GeneratedFile,
     channel_metadata,
@@ -42,31 +44,108 @@ def test_read_raw_timestamp_data():
     """ Test reading timestamp data as a raw TDMS timestamps
     """
     test_file = GeneratedFile()
+    seconds = 3672033330
+    second_fractions = 1234567890 * 10 ** 10
     test_file.add_segment(
         ("kTocMetaData", "kTocRawData", "kTocNewObjList"),
         segment_objects_metadata(
             channel_metadata("/'group'/'channel1'", 0x44, 4),
         ),
-        hexlify_value("<Q", 0000000000) + hexlify_value("<q", 3672033330) +
-        hexlify_value("<Q", 1234567890) + hexlify_value("<q", 3672033330) +
-        hexlify_value("<Q", 0000000000) + hexlify_value("<q", 3672033331) +
-        hexlify_value("<Q", 1234567890) + hexlify_value("<q", 3672033331)
+        hexlify_value("<Q", 0) + hexlify_value("<q", seconds) +
+        hexlify_value("<Q", second_fractions) + hexlify_value("<q", seconds) +
+        hexlify_value("<Q", 0) + hexlify_value("<q", seconds + 1) +
+        hexlify_value("<Q", second_fractions) + hexlify_value("<q", seconds + 1)
     )
 
-    expected_seconds = np.array([3672033330, 3672033331, 3672033330, 3672033331], np.dtype('int64'))
-    expected_second_fractions = np.array([0, 2000000000, 0, 2000000000], np.dtype('uint64'))
-    expected_timestamps = np.array([
-        np.datetime64('2020-05-11 09:15:30'),
-        np.datetime64('2020-05-11 09:15:30'),
-        np.datetime64('2020-05-11 09:15:31'),
-        np.datetime64('2020-05-11 09:15:31'),
-    ])
+    expected_seconds = np.array([seconds, seconds, seconds + 1, seconds + 1], np.dtype('int64'))
+    expected_second_fractions = np.array([0, second_fractions, 0, second_fractions], np.dtype('uint64'))
 
     with test_file.get_tempfile() as temp_file:
         tdms_data = TdmsFile.read(temp_file.file, raw_timestamps=True)
         data = tdms_data['group']['channel1'][:]
+        assert isinstance(data, TimestampArray)
         np.testing.assert_equal(data['seconds'], expected_seconds)
         np.testing.assert_equal(data['second_fractions'], expected_second_fractions)
-        np.testing.assert_equal(data.as_datetime64(), expected_timestamps)
 
 
+def test_timestamp_array_slicing():
+    timestamp_array = _get_test_timestamp_array()
+    array_slice = timestamp_array[0:2]
+    assert isinstance(array_slice, TimestampArray)
+
+
+def test_timestamp_array_get_single_item():
+    timestamp_array = _get_test_timestamp_array()
+    array_item = timestamp_array[3]
+    assert isinstance(array_item, TdmsTimestamp)
+    assert array_item.seconds == 3672033331
+    assert array_item.second_fractions == 1234567890 * 10 ** 10
+
+
+def test_timestamp_array_field_access():
+    timestamp_array = _get_test_timestamp_array()
+    seconds = timestamp_array['seconds']
+    second_fractions = timestamp_array['second_fractions']
+    assert isinstance(seconds, np.ndarray)
+    assert not isinstance(seconds, TimestampArray)
+    assert seconds.dtype == np.dtype('<i8')
+    assert isinstance(second_fractions, np.ndarray)
+    assert not isinstance(second_fractions, TimestampArray)
+    assert second_fractions.dtype == np.dtype('<u8')
+
+
+def test_timestamp_array_to_datetime64():
+    timestamp_array = _get_test_timestamp_array()
+    expected_timestamps = np.array([
+        np.datetime64('2020-05-11 09:15:30'),
+        np.datetime64('2020-05-11 09:15:30.669260'),
+        np.datetime64('2020-05-11 09:15:31'),
+        np.datetime64('2020-05-11 09:15:31.669260'),
+    ])
+
+    us_array = timestamp_array.as_datetime64()
+
+    np.testing.assert_equal(us_array, expected_timestamps)
+
+
+def test_timestamp_array_to_datetime64_with_ns_precision():
+    timestamp_array = _get_test_timestamp_array()
+    expected_timestamps = np.array([
+        np.datetime64('2020-05-11 09:15:30'),
+        np.datetime64('2020-05-11 09:15:30.669260594'),
+        np.datetime64('2020-05-11 09:15:31'),
+        np.datetime64('2020-05-11 09:15:31.669260594'),
+    ])
+
+    ns_array = timestamp_array.as_datetime64('ns')
+
+    np.testing.assert_equal(ns_array, expected_timestamps)
+
+
+@pytest.mark.parametrize(
+    "input_array",
+    [
+        np.array([1, 2, 3, 4]),
+        np.array([(1, 2), (3, 4)], dtype=[('a', '<i8'), ('b', '<u8')]),
+        np.array([(1, 2), (3, 4)], dtype=[('seconds', '<i8'), ('b', '<u8')]),
+        np.array([(1, 2), (3, 4)], dtype=[('a', '<i8'), ('second_fractions', '<u8')]),
+    ]
+)
+def test_error_raised_with_creating_timestamp_array_with_invalid_input_type(input_array):
+
+    with pytest.raises(ValueError) as exc_info:
+        _ = TimestampArray(input_array)
+    assert str(exc_info.value) == "Input array must have a dtype with 'seconds' and 'second_fractions' fields"
+
+
+def _get_test_timestamp_array():
+    dtype = np.dtype([('seconds', '<i8'), ('second_fractions', '<u8')])
+    seconds = 3672033330
+    second_fractions = 1234567890 * 10 ** 10
+    array = np.array([
+        (seconds, 0),
+        (seconds, second_fractions),
+        (seconds + 1, 0),
+        (seconds + 1, second_fractions),
+    ], dtype=dtype)
+    return TimestampArray(array)

--- a/nptdms/test/test_timestamps.py
+++ b/nptdms/test/test_timestamps.py
@@ -1,0 +1,72 @@
+""" Test reading timestamp properties and data
+"""
+
+import numpy as np
+from nptdms import TdmsFile
+from nptdms.test.util import (
+    GeneratedFile,
+    channel_metadata,
+    hexlify_value,
+    segment_objects_metadata,
+)
+
+
+def test_read_raw_timestamp_properties():
+    """ Test reading timestamp properties as a raw TDMS timestamp
+    """
+    test_file = GeneratedFile()
+    second_fractions = 1234567890 * 10 ** 10
+    properties = {
+        "wf_start_time": (0x44, hexlify_value("<Q", second_fractions) + hexlify_value("<q", 3524551547))
+    }
+    test_file.add_segment(
+        ("kTocMetaData", "kTocRawData", "kTocNewObjList"),
+        segment_objects_metadata(
+            channel_metadata("/'group'/'channel1'", 3, 2, properties),
+        ),
+        "01 00 00 00" "02 00 00 00"
+    )
+
+    with test_file.get_tempfile() as temp_file:
+        tdms_data = TdmsFile.read(temp_file.file, raw_timestamps=True)
+        start_time = tdms_data['group']['channel1'].properties['wf_start_time']
+        assert start_time.seconds == 3524551547
+        assert start_time.second_fractions == second_fractions
+        assert start_time.as_datetime64() == np.datetime64('2015-09-08T10:05:47.669260', 'us')
+        assert start_time.as_datetime64().dtype == np.dtype('datetime64[us]')
+        assert start_time.as_datetime64('ns') == np.datetime64('2015-09-08T10:05:47.669260594', 'ns')
+        assert start_time.as_datetime64('ns').dtype == np.dtype('datetime64[ns]')
+
+
+def test_read_raw_timestamp_data():
+    """ Test reading timestamp data as a raw TDMS timestamps
+    """
+    test_file = GeneratedFile()
+    test_file.add_segment(
+        ("kTocMetaData", "kTocRawData", "kTocNewObjList"),
+        segment_objects_metadata(
+            channel_metadata("/'group'/'channel1'", 0x44, 4),
+        ),
+        hexlify_value("<Q", 0000000000) + hexlify_value("<q", 3672033330) +
+        hexlify_value("<Q", 1234567890) + hexlify_value("<q", 3672033330) +
+        hexlify_value("<Q", 0000000000) + hexlify_value("<q", 3672033331) +
+        hexlify_value("<Q", 1234567890) + hexlify_value("<q", 3672033331)
+    )
+
+    expected_seconds = np.array([3672033330, 3672033331, 3672033330, 3672033331], np.dtype('int64'))
+    expected_second_fractions = np.array([0, 2000000000, 0, 2000000000], np.dtype('uint64'))
+    expected_timestamps = np.array([
+        np.datetime64('2020-05-11 09:15:30'),
+        np.datetime64('2020-05-11 09:15:30'),
+        np.datetime64('2020-05-11 09:15:31'),
+        np.datetime64('2020-05-11 09:15:31'),
+    ])
+
+    with test_file.get_tempfile() as temp_file:
+        tdms_data = TdmsFile.read(temp_file.file, raw_timestamps=True)
+        data = tdms_data['group']['channel1'][:]
+        np.testing.assert_equal(data['seconds'], expected_seconds)
+        np.testing.assert_equal(data['second_fractions'], expected_second_fractions)
+        np.testing.assert_equal(data.as_datetime64(), expected_timestamps)
+
+

--- a/nptdms/test/test_timestamps.py
+++ b/nptdms/test/test_timestamps.py
@@ -64,8 +64,18 @@ def test_read_raw_timestamp_data():
         tdms_data = TdmsFile.read(temp_file.file, raw_timestamps=True)
         data = tdms_data['group']['channel1'][:]
         assert isinstance(data, TimestampArray)
-        np.testing.assert_equal(data['seconds'], expected_seconds)
-        np.testing.assert_equal(data['second_fractions'], expected_second_fractions)
+        np.testing.assert_equal(data.seconds, expected_seconds)
+        np.testing.assert_equal(data.second_fractions, expected_second_fractions)
+
+
+def test_timestamp_repr():
+    timestamp = TdmsTimestamp(3672033330, 12345678900000000000)
+    assert repr(timestamp) == 'TdmsTimestamp(3672033330, 12345678900000000000)'
+
+
+def test_timestamp_str():
+    timestamp = TdmsTimestamp(3672033330, 12345678900000000000)
+    assert str(timestamp) == '2020-05-11T09:15:30.669261'
 
 
 def test_timestamp_array_slicing():
@@ -84,8 +94,8 @@ def test_timestamp_array_get_single_item():
 
 def test_timestamp_array_field_access():
     timestamp_array = _get_test_timestamp_array()
-    seconds = timestamp_array['seconds']
-    second_fractions = timestamp_array['second_fractions']
+    seconds = timestamp_array.seconds
+    second_fractions = timestamp_array.second_fractions
     assert isinstance(seconds, np.ndarray)
     assert not isinstance(seconds, TimestampArray)
     assert seconds.dtype == np.dtype('<i8')
@@ -132,7 +142,6 @@ def test_timestamp_array_to_datetime64_with_ns_precision():
     ]
 )
 def test_error_raised_with_creating_timestamp_array_with_invalid_input_type(input_array):
-
     with pytest.raises(ValueError) as exc_info:
         _ = TimestampArray(input_array)
     assert str(exc_info.value) == "Input array must have a dtype with 'seconds' and 'second_fractions' fields"

--- a/nptdms/test/test_timestamps.py
+++ b/nptdms/test/test_timestamps.py
@@ -1,6 +1,7 @@
 """ Test reading timestamp properties and data
 """
 
+from datetime import datetime
 import numpy as np
 import struct
 import pytest
@@ -36,10 +37,29 @@ def test_read_raw_timestamp_properties():
         start_time = tdms_data['group']['channel1'].properties['wf_start_time']
         assert start_time.seconds == 3524551547
         assert start_time.second_fractions == second_fractions
-        assert start_time.as_datetime64() == np.datetime64('2015-09-08T10:05:47.669260', 'us')
-        assert start_time.as_datetime64().dtype == np.dtype('datetime64[us]')
-        assert start_time.as_datetime64('ns') == np.datetime64('2015-09-08T10:05:47.669260594', 'ns')
-        assert start_time.as_datetime64('ns').dtype == np.dtype('datetime64[ns]')
+
+
+def test_timestamp_as_datetime64():
+    """ Test converting a timestamp to a numpy datetime64
+    """
+    second_fractions = 1234567890 * 10 ** 10
+    seconds = 3524551547
+    timestamp = TdmsTimestamp(seconds, second_fractions)
+
+    assert timestamp.as_datetime64() == np.datetime64('2015-09-08T10:05:47.669260', 'us')
+    assert timestamp.as_datetime64().dtype == np.dtype('datetime64[us]')
+    assert timestamp.as_datetime64('ns') == np.datetime64('2015-09-08T10:05:47.669260594', 'ns')
+    assert timestamp.as_datetime64('ns').dtype == np.dtype('datetime64[ns]')
+
+
+def test_timestamp_as_datetime():
+    """ Test converting a timestamp to a datetime.datetime
+    """
+    second_fractions = 1234567890 * 10 ** 10
+    seconds = 3524551547
+    timestamp = TdmsTimestamp(seconds, second_fractions)
+
+    assert timestamp.as_datetime() == datetime(2015, 9, 8, 10, 5, 47, 669261)
 
 
 def test_read_raw_timestamp_data():

--- a/nptdms/test/test_types.py
+++ b/nptdms/test/test_types.py
@@ -23,7 +23,7 @@ def test_timestamp_round_trip(time_string):
     timestamp = types.TimeStamp(expected_datetime)
     data_file = io.BytesIO(timestamp.bytes)
 
-    read_datetime = types.TimeStamp.read(data_file)
+    read_datetime = types.TimeStamp.read(data_file).as_datetime64()
 
     assert expected_datetime == read_datetime
 
@@ -39,7 +39,7 @@ def test_timestamp_from_datetime():
 
     read_datetime = types.TimeStamp.read(data_file)
 
-    assert expected_datetime == read_datetime
+    assert expected_datetime == read_datetime.as_datetime64()
 
 
 def test_timestamp_from_date():
@@ -53,4 +53,4 @@ def test_timestamp_from_date():
 
     read_datetime = types.TimeStamp.read(data_file)
 
-    assert expected_datetime == read_datetime
+    assert expected_datetime == read_datetime.as_datetime64()

--- a/nptdms/timestamp.py
+++ b/nptdms/timestamp.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+
+EPOCH = np.datetime64('1904-01-01 00:00:00', 's')
+
+
+class TdmsTimestamp(object):
+    """ A Timestamp from a TDMS file
+
+        The TDMS format stores timestamps as a signed number of seconds since the epoch 1904-01-01 00:00:00 UTC
+        and number of positive fractions (2^-64) of a second.
+
+        :ivar ~.seconds: Seconds since the epoch as a signed integer
+        :ivar ~.second_fractions: A positive number of 2^-64 fractions of a second
+    """
+
+    _fractions_per_step = {
+        's': 1.0 / 2 ** -64,
+        'ms': (10 ** -3) / 2 ** -64,
+        'us': (10 ** -6) / 2 ** -64,
+        'ns': (10 ** -9) / 2 ** -64,
+        'ps': (10 ** -12) / 2 ** -64,
+    }
+
+    def __init__(self, seconds, second_fractions):
+        self.seconds = seconds
+        self.second_fractions = second_fractions
+
+    def as_datetime64(self, resolution='us'):
+        try:
+            fractions_per_step = self._fractions_per_step[resolution]
+        except KeyError:
+            raise ValueError("Unsupported resolution for converting to numpy datetime64: {0}".format(resolution))
+        return (
+                EPOCH +
+                np.timedelta64(self.seconds, 's') +
+                ((self.second_fractions / fractions_per_step) * np.timedelta64(1, resolution)))

--- a/nptdms/timestamp.py
+++ b/nptdms/timestamp.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import numpy as np
 
 
@@ -40,6 +41,13 @@ class TdmsTimestamp(object):
                 EPOCH +
                 np.timedelta64(self.seconds, 's') +
                 ((self.second_fractions / fractions_per_step) * np.timedelta64(1, resolution)))
+
+    def as_datetime(self):
+        """ Convert this timestamp to a Python datetime.datetime object
+        """
+        fractions_per_us = _fractions_per_step['us']
+        microseconds = (self.second_fractions / fractions_per_us)
+        return datetime(1904, 1, 1, 0, 0, 0) + timedelta(seconds=self.seconds) + timedelta(microseconds=microseconds)
 
 
 class TimestampArray(np.ndarray):

--- a/nptdms/timestamp.py
+++ b/nptdms/timestamp.py
@@ -74,7 +74,7 @@ class TimestampArray(np.ndarray):
             # Getting a field, we don't want to return this as a TimestampArray
             # but as a normal numpy ndarray
             return val.view(np.ndarray)
-        if isinstance(item, int):
+        if isinstance(item, (int, np.number)):
             # Getting a single item
             return TdmsTimestamp(val[self._field_indices[0]], val[self._field_indices[1]])
         # else getting a slice returns a new TimestampArray

--- a/nptdms/timestamp.py
+++ b/nptdms/timestamp.py
@@ -14,24 +14,60 @@ class TdmsTimestamp(object):
         :ivar ~.second_fractions: A positive number of 2^-64 fractions of a second
     """
 
-    _fractions_per_step = {
-        's': 1.0 / 2 ** -64,
-        'ms': (10 ** -3) / 2 ** -64,
-        'us': (10 ** -6) / 2 ** -64,
-        'ns': (10 ** -9) / 2 ** -64,
-        'ps': (10 ** -12) / 2 ** -64,
-    }
-
     def __init__(self, seconds, second_fractions):
         self.seconds = seconds
         self.second_fractions = second_fractions
 
     def as_datetime64(self, resolution='us'):
         try:
-            fractions_per_step = self._fractions_per_step[resolution]
+            fractions_per_step = _fractions_per_step[resolution]
         except KeyError:
             raise ValueError("Unsupported resolution for converting to numpy datetime64: {0}".format(resolution))
         return (
                 EPOCH +
                 np.timedelta64(self.seconds, 's') +
                 ((self.second_fractions / fractions_per_step) * np.timedelta64(1, resolution)))
+
+
+class TimestampArray(np.ndarray):
+    """ A numpy array of TDMS timestamps
+
+        This must be constructed by passing a structured numpy array
+        with 'seconds' and 'second_fractions' fields.
+    """
+
+    def __new__(cls, input_array):
+        field_names = input_array.dtype.names
+        if field_names != ('seconds', 'second_fractions'):
+            raise ValueError("Input array must have a dtype with 'seconds' and 'second_fractions' fields")
+        return np.asarray(input_array).view(cls)
+
+    def __getitem__(self, item):
+        val = super(TimestampArray, self).__getitem__(item)
+        if isinstance(item, str):
+            # Getting a field, we don't want to return this as a TimestampArray
+            # but as a normal numpy ndarray
+            return val.view(np.ndarray)
+        if isinstance(item, int):
+            # Getting a single item
+            return TdmsTimestamp(val[0], val[1])
+        return val
+
+    def as_datetime64(self, resolution='us'):
+        try:
+            fractions_per_step = _fractions_per_step[resolution]
+        except KeyError:
+            raise ValueError("Unsupported resolution for converting to numpy datetime64: {0}".format(resolution))
+        return (
+                EPOCH +
+                self['seconds'] * np.timedelta64(1, 's') +
+                (self['second_fractions'] / fractions_per_step) * np.timedelta64(1, resolution))
+
+
+_fractions_per_step = {
+    's': 1.0 / 2 ** -64,
+    'ms': (10 ** -3) / 2 ** -64,
+    'us': (10 ** -6) / 2 ** -64,
+    'ns': (10 ** -9) / 2 ** -64,
+    'ps': (10 ** -12) / 2 ** -64,
+}

--- a/nptdms/timestamp.py
+++ b/nptdms/timestamp.py
@@ -35,7 +35,7 @@ class TdmsTimestamp(object):
         try:
             fractions_per_step = _fractions_per_step[resolution]
         except KeyError:
-            raise ValueError("Unsupported resolution for converting to numpy datetime64: {0}".format(resolution))
+            raise ValueError("Unsupported resolution for converting to numpy datetime64: '{0}'".format(resolution))
         return (
                 EPOCH +
                 np.timedelta64(self.seconds, 's') +
@@ -101,7 +101,7 @@ class TimestampArray(np.ndarray):
         try:
             fractions_per_step = _fractions_per_step[resolution]
         except KeyError:
-            raise ValueError("Unsupported resolution for converting to numpy datetime64: {0}".format(resolution))
+            raise ValueError("Unsupported resolution for converting to numpy datetime64: '{0}'".format(resolution))
         return (
                 EPOCH +
                 self['seconds'] * np.timedelta64(1, 's') +

--- a/nptdms/types.py
+++ b/nptdms/types.py
@@ -271,7 +271,7 @@ class TimeStamp(TdmsType):
         if endianness == "<":
             dtype = np.dtype([('second_fractions', '<u8'), ('seconds', '<i8')])
         else:
-            dtype = np.dtype([('seconds', '<i8'), ('second_fractions', '<u8')])
+            dtype = np.dtype([('seconds', '>i8'), ('second_fractions', '>u8')])
         return TimestampArray(byte_array.view(dtype).reshape(-1))
 
 

--- a/nptdms/types.py
+++ b/nptdms/types.py
@@ -272,7 +272,7 @@ class TimeStamp(TdmsType):
             dtype = np.dtype([('second_fractions', '<u8'), ('seconds', '<i8')])
         else:
             dtype = np.dtype([('seconds', '<i8'), ('second_fractions', '<u8')])
-        return TimestampArray(byte_array.view(dtype).reshape(-1)).as_datetime64()
+        return TimestampArray(byte_array.view(dtype).reshape(-1))
 
 
 @tds_data_type(0x08000c, np.complex64)

--- a/nptdms/types.py
+++ b/nptdms/types.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import struct
+from nptdms.timestamp import TdmsTimestamp
 
 
 __all__ = [
@@ -230,9 +231,6 @@ class TimeStamp(TdmsType):
     # 01/01/1904 00:00:00.00 UTC, ignoring leap seconds,
     # and number of 2^-64 fractions of a second.
     # Note that the TDMS epoch is not the Unix epoch.
-
-    # We convert times to numpy datetime64s with microsecond precision,
-    # so lose some precision compared with  TDMS.
     _tdms_epoch = np.datetime64('1904-01-01 00:00:00', 'us')
     _fractions_per_microsecond = float(10**-6) / 2**-64
 
@@ -263,11 +261,7 @@ class TimeStamp(TdmsType):
         else:
             (seconds, second_fractions) = _struct_unpack(
                  endianness + 'qQ', data)
-        micro_seconds = int(
-            float(second_fractions) / cls._fractions_per_microsecond)
-
-        return (cls._tdms_epoch + np.timedelta64(seconds, 's') +
-                np.timedelta64(micro_seconds, 'us'))
+        return TdmsTimestamp(seconds, second_fractions)
 
     @classmethod
     def from_bytes(cls, byte_array, endianness="<"):

--- a/nptdms/types.py
+++ b/nptdms/types.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import struct
-from nptdms.timestamp import TdmsTimestamp
+from nptdms.timestamp import TdmsTimestamp, TimestampArray
 
 
 __all__ = [
@@ -269,15 +269,10 @@ class TimeStamp(TdmsType):
         """
         byte_array = byte_array.reshape((-1, 16))
         if endianness == "<":
-            second_fractions = byte_array[:, 0:8].ravel()
-            seconds = byte_array[:, 8:16].ravel()
+            dtype = np.dtype([('second_fractions', '<u8'), ('seconds', '<i8')])
         else:
-            seconds = byte_array[:, 0:8].ravel()
-            second_fractions = byte_array[:, 8:16].ravel()
-        seconds.dtype = np.dtype('timedelta64[s]').newbyteorder(endianness)
-        second_fractions.dtype = np.dtype('uint64').newbyteorder(endianness)
-        micro_seconds = (second_fractions / cls._fractions_per_microsecond) * np.timedelta64(1, 'us')
-        return cls._tdms_epoch + seconds + micro_seconds
+            dtype = np.dtype([('seconds', '<i8'), ('second_fractions', '<u8')])
+        return TimestampArray(byte_array.view(dtype).reshape(-1)).as_datetime64()
 
 
 @tds_data_type(0x08000c, np.complex64)


### PR DESCRIPTION
Addresses #198

Adds a new `raw_timestamps` option when opening a TDMS file that controls whether timestamps are read as numpy datetime64 objects or raw TDMS timestamps. This includes timestamp data in channels, which use a new TimestampArray type that wraps np.ndarray and provides conversion to datetime64 arrays of different resolution.