### PR TITLE
writer: add support for np.bool_ properties

### DIFF
--- a/nptdms/test/writer/test_tdms_segment.py
+++ b/nptdms/test/writer/test_tdms_segment.py
@@ -176,6 +176,7 @@ def test_writing_properties_with_numpy_typed_values():
         "int64prop": np.int64(64),
         "float32prop": np.float32(32.0),
         "float64prop": np.float64(64.0),
+        "boolprop": np.bool_(True),
     }
 
     tdms_properties = read_properties_dict(properties)
@@ -185,6 +186,7 @@ def test_writing_properties_with_numpy_typed_values():
     assert tdms_properties["int64prop"] == Int64(64)
     assert tdms_properties["float32prop"] == SingleFloat(32.0)
     assert tdms_properties["float64prop"] == DoubleFloat(64.0)
+    assert tdms_properties["boolprop"] == Boolean(True)
 
 
 def test_error_raised_when_cannot_convert_property_value():

--- a/nptdms/writer.py
+++ b/nptdms/writer.py
@@ -266,7 +266,7 @@ def _to_tdms_value(value):
         return numpy_data_types[value.dtype](value)
     if isinstance(value, TdmsType):
         return value
-    if isinstance(value, bool):
+    if isinstance(value, bool) or isinstance(value, np.bool_):
         return Boolean(value)
     if isinstance(value, (int, long)):
         return to_int_property_value(value)


### PR DESCRIPTION
Commit 5f4f282 added support for numpy numeric values, but didn't
include support for np.bool_.

Signed-off-by: Alejandro del Castillo <alejandro.delcastillo@ni.com>