### PR TITLE
Handle non-raw DAQmx data

### DIFF
--- a/nptdms/base_segment.py
+++ b/nptdms/base_segment.py
@@ -1,319 +1,10 @@
-from copy import copy
 from io import UnsupportedOperation
-import os
-import struct
 import numpy as np
 
-from nptdms import types
-from nptdms.common import toc_properties
 from nptdms.log import log_manager
 
 
 log = log_manager.get_logger(__name__)
-_struct_unpack = struct.unpack
-
-RAW_DATA_INDEX_NO_DATA = 0xFFFFFFFF
-RAW_DATA_INDEX_MATCHES_PREVIOUS = 0x00000000
-
-
-class BaseSegment(object):
-    """ Abstract base class for TDMS segments
-    """
-
-    __slots__ = [
-        'position', 'num_chunks', 'ordered_objects', 'toc_mask',
-        'next_segment_offset', 'next_segment_pos',
-        'raw_data_offset', 'data_position', 'final_chunk_proportion',
-        'endianness', 'object_properties']
-
-    def __init__(
-            self, position, toc_mask, endianness, next_segment_offset,
-            next_segment_pos, raw_data_offset, data_position):
-        self.position = position
-        self.toc_mask = toc_mask
-        self.endianness = endianness
-        self.next_segment_offset = next_segment_offset
-        self.next_segment_pos = next_segment_pos
-        self.raw_data_offset = raw_data_offset
-        self.data_position = data_position
-        self.num_chunks = 0
-        self.final_chunk_proportion = 1.0
-        self.ordered_objects = []
-        self.object_properties = None
-
-    def __repr__(self):
-        return "<TdmsSegment at position %d>" % self.position
-
-    def read_segment_objects(self, file, previous_segment_objects, previous_segment=None):
-        """Read segment metadata section and update object information
-
-        :param file: Open TDMS file
-        :param previous_segment_objects: Dictionary of path to the most
-            recently read segment object for a TDMS object.
-        :param previous_segment: Previous segment in the file.
-        """
-
-        if not self.toc_mask & toc_properties['kTocMetaData']:
-            self._reuse_previous_segment_metadata(previous_segment)
-            return
-
-        endianness = self.endianness
-
-        new_obj_list = self.toc_mask & toc_properties['kTocNewObjList']
-        if not new_obj_list:
-            # In this case, there can be a list of new objects that
-            # are appended, or previous objects can also be repeated
-            # if their properties change.
-            # Copy the list of objects for now, but any objects that have
-            # metadata changed will need to be copied before being modified.
-            self.ordered_objects = [
-                o for o in previous_segment.ordered_objects]
-            existing_objects = {o.path: (i, o) for (i, o) in enumerate(self.ordered_objects)}
-        else:
-            existing_objects = None
-
-        log.debug("Reading segment object metadata at %d", file.tell())
-
-        # First four bytes have number of objects in metadata
-        num_objects_bytes = file.read(4)
-        num_objects = _struct_unpack(endianness + 'L', num_objects_bytes)[0]
-
-        for _ in range(num_objects):
-            # Read the object path
-            object_path = types.String.read(file, endianness)
-            raw_data_index_header_bytes = file.read(4)
-            raw_data_index_header = _struct_unpack(endianness + 'L', raw_data_index_header_bytes)[0]
-            log.debug("Reading metadata for object %s with index header 0x%08x", object_path, raw_data_index_header)
-
-            # Check whether we already have this object in our list from
-            # the last segment
-            (existing_object_index, existing_object) = (
-                self._get_existing_object(existing_objects, object_path)
-                if existing_objects is not None
-                else (None, None))
-            if existing_object_index is not None:
-                self._update_existing_object(
-                    object_path, existing_object_index, existing_object, raw_data_index_header, file)
-            elif object_path in previous_segment_objects:
-                previous_segment_obj = previous_segment_objects[object_path]
-                self._reuse_previous_object(
-                    object_path, previous_segment_obj, raw_data_index_header, file)
-            else:
-                segment_obj = self._new_segment_object(object_path)
-                self.ordered_objects.append(segment_obj)
-                if raw_data_index_header == RAW_DATA_INDEX_MATCHES_PREVIOUS:
-                    raise ValueError("Raw data index for %s says to reuse previous structure, "
-                                     "but we have not seen this object before" % object_path)
-                elif raw_data_index_header != RAW_DATA_INDEX_NO_DATA:
-                    segment_obj.has_data = True
-                    segment_obj.read_raw_data_index(file, raw_data_index_header)
-
-            self._read_object_properties(file, object_path)
-        self._calculate_chunks()
-
-    def _update_existing_object(
-            self, object_path, existing_object_index, existing_object, raw_data_index_header, file):
-        """ Update raw data index information for an object already in the list of segment objects
-        """
-        if raw_data_index_header == RAW_DATA_INDEX_NO_DATA:
-            # Re-use object but leave data index information as set previously
-            if existing_object.has_data:
-                new_obj = copy(existing_object)
-                new_obj.has_data = False
-                self.ordered_objects[existing_object_index] = new_obj
-        elif raw_data_index_header == RAW_DATA_INDEX_MATCHES_PREVIOUS:
-            # Re-use object and ensure we set has data to true for this segment
-            if not existing_object.has_data:
-                new_obj = copy(existing_object)
-                new_obj.has_data = True
-                self.ordered_objects[existing_object_index] = new_obj
-        else:
-            # New segment metadata, or updates to existing data
-            segment_obj = self._new_segment_object(object_path)
-            segment_obj.has_data = True
-            segment_obj.read_raw_data_index(file, raw_data_index_header)
-            self.ordered_objects[existing_object_index] = segment_obj
-
-    def _reuse_previous_object(
-            self, object_path, previous_segment_obj, raw_data_index_header, file):
-        """ Attempt to reuse raw data index information from a previous segment
-        """
-        if raw_data_index_header == RAW_DATA_INDEX_NO_DATA:
-            # Re-use object but leave data index information as set previously
-            if previous_segment_obj.has_data:
-                segment_obj = copy(previous_segment_obj)
-                segment_obj.has_data = False
-            else:
-                segment_obj = previous_segment_obj
-        elif raw_data_index_header == RAW_DATA_INDEX_MATCHES_PREVIOUS:
-            # Re-use previous object and ensure we set has data to true for this segment
-            if not previous_segment_obj.has_data:
-                segment_obj = copy(previous_segment_obj)
-                segment_obj.has_data = True
-            else:
-                segment_obj = previous_segment_obj
-        else:
-            # Changed metadata in this segment
-            segment_obj = self._new_segment_object(object_path)
-            segment_obj.has_data = True
-            segment_obj.read_raw_data_index(file, raw_data_index_header)
-        self.ordered_objects.append(segment_obj)
-
-    def _reuse_previous_segment_metadata(self, previous_segment):
-        try:
-            self.ordered_objects = previous_segment.ordered_objects
-            self._calculate_chunks()
-        except AttributeError:
-            raise ValueError(
-                "kTocMetaData is not set for segment but "
-                "there is no previous segment")
-
-    def _get_existing_object(self, existing_objects, object_path):
-        """ Find an object already in the list of objects that are reused from the previous segment
-        """
-        try:
-            return existing_objects[object_path]
-        except KeyError:
-            return None, None
-
-    def _read_object_properties(self, file, object_path):
-        """Read properties for an object in the segment
-        """
-        num_properties_bytes = file.read(4)
-        num_properties = _struct_unpack(self.endianness + 'L', num_properties_bytes)[0]
-        if num_properties > 0:
-            log.debug("Reading %d properties", num_properties)
-            if self.object_properties is None:
-                self.object_properties = {}
-            self.object_properties[object_path] = [
-                read_property(file, self.endianness)
-                for _ in range(num_properties)]
-
-    def read_raw_data(self, f):
-        """Read raw data from a TDMS segment
-
-        :returns: A generator of RawDataChunk objects with raw channel data for
-            objects in this segment.
-        """
-
-        if not self.toc_mask & toc_properties['kTocRawData']:
-            yield RawDataChunk.empty()
-
-        f.seek(self.data_position)
-
-        total_data_size = self.next_segment_offset - self.raw_data_offset
-        log.debug(
-            "Reading %d bytes of data at %d in %d chunks",
-            total_data_size, f.tell(), self.num_chunks)
-
-        data_objects = [o for o in self.ordered_objects if o.has_data]
-        for chunk in self._read_data_chunks(f, data_objects, self.num_chunks):
-            yield chunk
-
-    def read_raw_data_for_channel(self, f, channel_path, chunk_offset=0, num_chunks=None):
-        """Read raw data from a TDMS segment
-
-        :param f: Open TDMS file object
-        :param channel_path: Path of channel to read data for
-        :param chunk_offset: Index of chunk to begin reading from
-        :param num_chunks: Number of chunks to read, or None to read to the end
-        :returns: A generator of RawChannelDataChunk objects with raw channel data for
-            a single channel in this segment.
-        """
-
-        if not self.toc_mask & toc_properties['kTocRawData']:
-            yield RawChannelDataChunk.empty()
-
-        f.seek(self.data_position)
-
-        data_objects = [o for o in self.ordered_objects if o.has_data]
-        chunk_size = self._get_chunk_size()
-
-        if chunk_offset > 0:
-            f.seek(chunk_size * chunk_offset, os.SEEK_CUR)
-        stop_chunk = self.num_chunks if num_chunks is None else num_chunks + chunk_offset
-        for chunk in self._read_channel_data_chunks(f, data_objects, channel_path, chunk_offset, stop_chunk):
-            yield chunk
-
-    def _calculate_chunks(self):
-        """
-        Work out the number of chunks the data is in, for cases
-        where the meta data doesn't change at all so there is no
-        lead in.
-        """
-
-        data_size = self._get_chunk_size()
-
-        total_data_size = self.next_segment_offset - self.raw_data_offset
-        if data_size < 0 or total_data_size < 0:
-            raise ValueError("Negative data size")
-        elif data_size == 0:
-            # Sometimes kTocRawData is set, but there isn't actually any data
-            if total_data_size != data_size:
-                raise ValueError(
-                    "Zero channel data size but data length based on "
-                    "segment offset is %d." % total_data_size)
-            self.num_chunks = 0
-            return
-        chunk_remainder = total_data_size % data_size
-        if chunk_remainder == 0:
-            self.num_chunks = int(total_data_size // data_size)
-        else:
-            log.warning(
-                "Data size %d is not a multiple of the "
-                "chunk size %d. Will attempt to read last chunk",
-                total_data_size, data_size)
-            self.num_chunks = 1 + int(total_data_size // data_size)
-            self.final_chunk_proportion = (
-                    float(chunk_remainder) / float(data_size))
-
-    def _get_chunk_size(self):
-        return sum([
-            o.data_size
-            for o in self.ordered_objects if o.has_data])
-
-    def _read_data_chunks(self, file, data_objects, num_chunks):
-        """ Read multiple data chunks at once
-            In the base case we read each chunk individually but subclasses can override this
-        """
-        for chunk in range(num_chunks):
-            yield self._read_data_chunk(file, data_objects, chunk)
-
-    def _read_data_chunk(self, file, data_objects, chunk_index):
-        """ Read data from a chunk for all channels
-        """
-        raise NotImplementedError("Data chunk reading must be implemented in base classes")
-
-    def _read_channel_data_chunks(self, file, data_objects, channel_path, chunk_offset, stop_chunk):
-        """ Read multiple data chunks for a single channel at once
-            In the base case we read each chunk individually but subclasses can override this
-        """
-        for chunk_index in range(chunk_offset, stop_chunk):
-            yield self._read_channel_data_chunk(file, data_objects, chunk_index, channel_path)
-
-    def _read_channel_data_chunk(self, file, data_objects, chunk_index, channel_path):
-        """ Read data from a chunk for a single channel
-        """
-        # In the base case we can read data for all channels
-        # and then select only the requested channel.
-        # Derived classes can implement more optimised reading.
-        data_chunk = self._read_data_chunk(file, data_objects, chunk_index)
-        return BaseSegment._data_chunk_to_channel_chunk(data_chunk, channel_path)
-
-    @staticmethod
-    def _data_chunk_to_channel_chunk(data_chunk, channel_path):
-        try:
-            return data_chunk.channel_data[channel_path]
-        except KeyError:
-            return RawChannelDataChunk.empty()
-
-    def _new_segment_object(self, object_path):
-        """ Create a new segment object for a segment
-
-        :param object_path: Path for the object
-        """
-
-        raise NotImplementedError("New segment object creation must be implemented in base classes")
 
 
 class BaseSegmentObject(object):
@@ -340,6 +31,44 @@ class BaseSegmentObject(object):
     @property
     def scaler_data_types(self):
         return None
+
+
+class BaseDataReader(object):
+    """ Abstract base class for reading data in a segment
+    """
+
+    def __init__(self, num_chunks, final_chunk_proportion, endianness):
+        self.num_chunks = num_chunks
+        self.final_chunk_proportion = final_chunk_proportion
+        self.endianness = endianness
+
+    def read_data_chunks(self, file, data_objects, num_chunks):
+        """ Read multiple data chunks at once
+            In the base case we read each chunk individually but subclasses can override this
+        """
+        for chunk in range(num_chunks):
+            yield self._read_data_chunk(file, data_objects, chunk)
+
+    def _read_data_chunk(self, file, data_objects, chunk_index):
+        """ Read data from a chunk for all channels
+        """
+        raise NotImplementedError("Data chunk reading must be implemented in base classes")
+
+    def read_channel_data_chunks(self, file, data_objects, channel_path, chunk_offset, stop_chunk):
+        """ Read multiple data chunks for a single channel at once
+            In the base case we read each chunk individually but subclasses can override this
+        """
+        for chunk_index in range(chunk_offset, stop_chunk):
+            yield self._read_channel_data_chunk(file, data_objects, chunk_index, channel_path)
+
+    def _read_channel_data_chunk(self, file, data_objects, chunk_index, channel_path):
+        """ Read data from a chunk for a single channel
+        """
+        # In the base case we can read data for all channels
+        # and then select only the requested channel.
+        # Derived classes can implement more optimised reading.
+        data_chunk = self._read_data_chunk(file, data_objects, chunk_index)
+        return data_chunk_to_channel_chunk(data_chunk, channel_path)
 
 
 class RawDataChunk(object):
@@ -405,16 +134,6 @@ class RawChannelDataChunk(object):
         return RawChannelDataChunk(None, data)
 
 
-def read_property(f, endianness="<"):
-    """ Read a property from a segment's metadata """
-
-    prop_name = types.String.read(f, endianness)
-    prop_data_type = types.tds_data_types[types.Uint32.read(f, endianness)]
-    value = prop_data_type.read(f, endianness)
-    log.debug("Property '%s' = %r", prop_name, value)
-    return prop_name, value
-
-
 def fromfile(file, dtype, count, *args, **kwargs):
     """Wrapper around np.fromfile to support any file-like object"""
 
@@ -444,3 +163,10 @@ def read_interleaved_segment_bytes(f, bytes_per_row, num_values):
                     combined_data.shape[0], crop_len)
         combined_data = combined_data[:crop_len].reshape(-1, bytes_per_row)
     return combined_data
+
+
+def data_chunk_to_channel_chunk(data_chunk, channel_path):
+    try:
+        return data_chunk.channel_data[channel_path]
+    except KeyError:
+        return RawChannelDataChunk.empty()

--- a/nptdms/base_segment.py
+++ b/nptdms/base_segment.py
@@ -32,6 +32,9 @@ class BaseSegmentObject(object):
     def scaler_data_types(self):
         return None
 
+    def __repr__(self):
+        return "%s(%s)" % (self.__class__.__name__, self.path)
+
 
 class BaseDataReader(object):
     """ Abstract base class for reading data in a segment

--- a/nptdms/reader.py
+++ b/nptdms/reader.py
@@ -9,8 +9,7 @@ from nptdms import types
 from nptdms.common import ObjectPath, toc_properties
 from nptdms.utils import Timer, OrderedDict
 from nptdms.base_segment import RawChannelDataChunk
-from nptdms.tdms_segment import ContiguousDataSegment, InterleavedDataSegment
-from nptdms.daqmx import DaqmxSegment
+from nptdms.tdms_segment import TdmsSegment
 from nptdms.log import log_manager
 
 
@@ -221,15 +220,9 @@ class TdmsReader(object):
         (position, toc_mask, endianness, data_position, raw_data_offset,
          next_segment_offset, next_segment_pos) = self._read_lead_in(file, segment_position, is_index_file)
 
-        segment_args = (
+        segment = TdmsSegment(
             position, toc_mask, endianness, next_segment_offset,
             next_segment_pos, raw_data_offset, data_position)
-        if toc_mask & toc_properties['kTocDAQmxRawData']:
-            segment = DaqmxSegment(*segment_args)
-        elif toc_mask & toc_properties['kTocInterleavedData']:
-            segment = InterleavedDataSegment(*segment_args)
-        else:
-            segment = ContiguousDataSegment(*segment_args)
 
         segment.read_segment_objects(
             file, self._prev_segment_objects, previous_segment)

--- a/nptdms/scaling.py
+++ b/nptdms/scaling.py
@@ -13,6 +13,25 @@ VOLTAGE_EXCITATION = 10322
 CURRENT_EXCITATION = 10134
 
 
+class NoOpScaling(object):
+    """ Does not apply any scaling
+    """
+    def __init__(self, input_source):
+        self.input_source = input_source
+
+    @staticmethod
+    def from_properties(properties, scale_index, scale_name):
+        try:
+            input_source = properties[
+                "NI_Scale[%d]_%s_Input_Source" % (scale_index, scale_name)]
+        except KeyError:
+            input_source = RAW_DATA_INPUT_SOURCE
+        return NoOpScaling(input_source)
+
+    def scale(self, data):
+        return data
+
+
 class LinearScaling(object):
     """ Linear scaling with slope and intercept
     """
@@ -385,6 +404,8 @@ class MultiScaling(object):
             return np.result_type(
                 self._compute_scale_dtype(scaling.left_input_source, raw_data_type, scaler_data_types),
                 self._compute_scale_dtype(scaling.right_input_source, raw_data_type, scaler_data_types))
+        elif isinstance(scaling, NoOpScaling):
+            return raw_data_type.nptype
         else:
             # Any other scaling type should produce double data
             return np.dtype('float64')
@@ -475,6 +496,9 @@ def _get_channel_scaling(properties):
         elif scale_type == 'Subtract':
             scalings[scale_index] = SubtractScaling.from_properties(
                 properties, scale_index)
+        elif scale_type == 'AdvancedAPI':
+            scalings[scale_index] = NoOpScaling.from_properties(
+                properties, scale_index, 'AdvancedAPI')
         else:
             log.warning("Unsupported scale type: %s", scale_type)
             return None

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -387,12 +387,7 @@ class InterleavedDataReader(BaseDataReader):
             # be number of bytes per point * number of data points.
             # Then use ravel to flatten the results into a vector.
             object_data = combined_data[:, byte_columns].ravel()
-            if obj.data_type.nptype is not None:
-                # Set correct data type, so that the array length should be correct
-                object_data.dtype = (
-                    obj.data_type.nptype.newbyteorder(self.endianness))
-            else:
-                object_data = obj.data_type.from_bytes(object_data, self.endianness)
+            object_data = obj.data_type.from_bytes(object_data, self.endianness)
             channel_data[obj.path] = object_data
             data_pos += obj.data_type.size
 

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -1,30 +1,343 @@
+from copy import copy
 import os
 import numpy as np
+import struct
 
 from nptdms import types
+from nptdms.common import toc_properties
+from nptdms.log import log_manager
 from nptdms.base_segment import (
-    BaseSegment,
     BaseSegmentObject,
+    BaseDataReader,
     RawChannelDataChunk,
     RawDataChunk,
     read_interleaved_segment_bytes,
+    data_chunk_to_channel_chunk,
     fromfile)
-from nptdms.log import log_manager
+from nptdms.daqmx import (
+    FORMAT_CHANGING_SCALER,
+    DIGITAL_LINE_SCALER,
+    DaqmxSegmentObject,
+    DaqmxDataReader,
+    get_daqmx_chunk_size)
 
 
+_struct_unpack = struct.unpack
 log = log_manager.get_logger(__name__)
 
 
-class InterleavedDataSegment(BaseSegment):
-    """ A TDMS segment with interleaved data
+RAW_DATA_INDEX_NO_DATA = 0xFFFFFFFF
+RAW_DATA_INDEX_MATCHES_PREVIOUS = 0x00000000
+
+
+class TdmsSegment(object):
+    """ Represents a segment of data in a TDMS file
     """
 
-    __slots__ = []
+    __slots__ = [
+        'position', 'num_chunks', 'ordered_objects', 'toc_mask',
+        'next_segment_offset', 'next_segment_pos',
+        'raw_data_offset', 'data_position', 'final_chunk_proportion',
+        'endianness', 'object_properties']
 
-    def _new_segment_object(self, object_path):
+    def __init__(
+            self, position, toc_mask, endianness, next_segment_offset,
+            next_segment_pos, raw_data_offset, data_position):
+        self.position = position
+        self.toc_mask = toc_mask
+        self.endianness = endianness
+        self.next_segment_offset = next_segment_offset
+        self.next_segment_pos = next_segment_pos
+        self.raw_data_offset = raw_data_offset
+        self.data_position = data_position
+        self.num_chunks = 0
+        self.final_chunk_proportion = 1.0
+        self.ordered_objects = []
+        self.object_properties = None
+
+    def __repr__(self):
+        return "<TdmsSegment at position %d>" % self.position
+
+    def read_segment_objects(self, file, previous_segment_objects, previous_segment=None):
+        """Read segment metadata section and update object information
+
+        :param file: Open TDMS file
+        :param previous_segment_objects: Dictionary of path to the most
+            recently read segment object for a TDMS object.
+        :param previous_segment: Previous segment in the file.
+        """
+
+        if not self.toc_mask & toc_properties['kTocMetaData']:
+            self._reuse_previous_segment_metadata(previous_segment)
+            return
+
+        endianness = self.endianness
+
+        new_obj_list = self.toc_mask & toc_properties['kTocNewObjList']
+        if not new_obj_list:
+            # In this case, there can be a list of new objects that
+            # are appended, or previous objects can also be repeated
+            # if their properties change.
+            # Copy the list of objects for now, but any objects that have
+            # metadata changed will need to be copied before being modified.
+            self.ordered_objects = [
+                o for o in previous_segment.ordered_objects]
+            existing_objects = {o.path: (i, o) for (i, o) in enumerate(self.ordered_objects)}
+        else:
+            existing_objects = None
+
+        log.debug("Reading segment object metadata at %d", file.tell())
+
+        # First four bytes have number of objects in metadata
+        num_objects_bytes = file.read(4)
+        num_objects = _struct_unpack(endianness + 'L', num_objects_bytes)[0]
+
+        for _ in range(num_objects):
+            # Read the object path
+            object_path = types.String.read(file, endianness)
+            raw_data_index_header_bytes = file.read(4)
+            raw_data_index_header = _struct_unpack(endianness + 'L', raw_data_index_header_bytes)[0]
+            log.debug("Reading metadata for object %s with index header 0x%08x", object_path, raw_data_index_header)
+
+            # Check whether we already have this object in our list from
+            # the last segment
+            (existing_object_index, existing_object) = (
+                self._get_existing_object(existing_objects, object_path)
+                if existing_objects is not None
+                else (None, None))
+            if existing_object_index is not None:
+                self._update_existing_object(
+                    object_path, existing_object_index, existing_object, raw_data_index_header, file)
+            elif object_path in previous_segment_objects:
+                previous_segment_obj = previous_segment_objects[object_path]
+                self._reuse_previous_object(
+                    object_path, previous_segment_obj, raw_data_index_header, file)
+            else:
+                segment_obj = self._new_segment_object(object_path, raw_data_index_header)
+                self.ordered_objects.append(segment_obj)
+                if raw_data_index_header == RAW_DATA_INDEX_MATCHES_PREVIOUS:
+                    raise ValueError("Raw data index for %s says to reuse previous structure, "
+                                     "but we have not seen this object before" % object_path)
+                elif raw_data_index_header != RAW_DATA_INDEX_NO_DATA:
+                    segment_obj.has_data = True
+                    segment_obj.read_raw_data_index(file, raw_data_index_header)
+
+            self._read_object_properties(file, object_path)
+        self._calculate_chunks()
+
+    def _update_existing_object(
+            self, object_path, existing_object_index, existing_object, raw_data_index_header, file):
+        """ Update raw data index information for an object already in the list of segment objects
+        """
+        if raw_data_index_header == RAW_DATA_INDEX_NO_DATA:
+            # Re-use object but leave data index information as set previously
+            if existing_object.has_data:
+                new_obj = copy(existing_object)
+                new_obj.has_data = False
+                self.ordered_objects[existing_object_index] = new_obj
+        elif raw_data_index_header == RAW_DATA_INDEX_MATCHES_PREVIOUS:
+            # Re-use object and ensure we set has data to true for this segment
+            if not existing_object.has_data:
+                new_obj = copy(existing_object)
+                new_obj.has_data = True
+                self.ordered_objects[existing_object_index] = new_obj
+        else:
+            # New segment metadata, or updates to existing data
+            segment_obj = self._new_segment_object(object_path, raw_data_index_header)
+            segment_obj.has_data = True
+            segment_obj.read_raw_data_index(file, raw_data_index_header)
+            self.ordered_objects[existing_object_index] = segment_obj
+
+    def _reuse_previous_object(
+            self, object_path, previous_segment_obj, raw_data_index_header, file):
+        """ Attempt to reuse raw data index information from a previous segment
+        """
+        if raw_data_index_header == RAW_DATA_INDEX_NO_DATA:
+            # Re-use object but leave data index information as set previously
+            if previous_segment_obj.has_data:
+                segment_obj = copy(previous_segment_obj)
+                segment_obj.has_data = False
+            else:
+                segment_obj = previous_segment_obj
+        elif raw_data_index_header == RAW_DATA_INDEX_MATCHES_PREVIOUS:
+            # Re-use previous object and ensure we set has data to true for this segment
+            if not previous_segment_obj.has_data:
+                segment_obj = copy(previous_segment_obj)
+                segment_obj.has_data = True
+            else:
+                segment_obj = previous_segment_obj
+        else:
+            # Changed metadata in this segment
+            segment_obj = self._new_segment_object(object_path, raw_data_index_header)
+            segment_obj.has_data = True
+            segment_obj.read_raw_data_index(file, raw_data_index_header)
+        self.ordered_objects.append(segment_obj)
+
+    def _reuse_previous_segment_metadata(self, previous_segment):
+        try:
+            self.ordered_objects = previous_segment.ordered_objects
+            self._calculate_chunks()
+        except AttributeError:
+            raise ValueError(
+                "kTocMetaData is not set for segment but "
+                "there is no previous segment")
+
+    def _get_existing_object(self, existing_objects, object_path):
+        """ Find an object already in the list of objects that are reused from the previous segment
+        """
+        try:
+            return existing_objects[object_path]
+        except KeyError:
+            return None, None
+
+    def _read_object_properties(self, file, object_path):
+        """Read properties for an object in the segment
+        """
+        num_properties_bytes = file.read(4)
+        num_properties = _struct_unpack(self.endianness + 'L', num_properties_bytes)[0]
+        if num_properties > 0:
+            log.debug("Reading %d properties", num_properties)
+            if self.object_properties is None:
+                self.object_properties = {}
+            self.object_properties[object_path] = [
+                read_property(file, self.endianness)
+                for _ in range(num_properties)]
+
+    def read_raw_data(self, f):
+        """Read raw data from a TDMS segment
+
+        :returns: A generator of RawDataChunk objects with raw channel data for
+            objects in this segment.
+        """
+
+        if not self.toc_mask & toc_properties['kTocRawData']:
+            yield RawDataChunk.empty()
+
+        f.seek(self.data_position)
+
+        total_data_size = self.next_segment_offset - self.raw_data_offset
+        log.debug(
+            "Reading %d bytes of data at %d in %d chunks",
+            total_data_size, f.tell(), self.num_chunks)
+
+        data_objects = [o for o in self.ordered_objects if o.has_data]
+        for chunk in self._read_data_chunks(f, data_objects, self.num_chunks):
+            yield chunk
+
+    def read_raw_data_for_channel(self, f, channel_path, chunk_offset=0, num_chunks=None):
+        """Read raw data from a TDMS segment
+
+        :param f: Open TDMS file object
+        :param channel_path: Path of channel to read data for
+        :param chunk_offset: Index of chunk to begin reading from
+        :param num_chunks: Number of chunks to read, or None to read to the end
+        :returns: A generator of RawChannelDataChunk objects with raw channel data for
+            a single channel in this segment.
+        """
+
+        if not self.toc_mask & toc_properties['kTocRawData']:
+            yield RawChannelDataChunk.empty()
+
+        f.seek(self.data_position)
+
+        data_objects = [o for o in self.ordered_objects if o.has_data]
+        chunk_size = self._get_chunk_size()
+
+        if chunk_offset > 0:
+            f.seek(chunk_size * chunk_offset, os.SEEK_CUR)
+        stop_chunk = self.num_chunks if num_chunks is None else num_chunks + chunk_offset
+        for chunk in self._read_channel_data_chunks(f, data_objects, channel_path, chunk_offset, stop_chunk):
+            yield chunk
+
+    def _calculate_chunks(self):
+        """
+        Work out the number of chunks the data is in, for cases
+        where the meta data doesn't change at all so there is no
+        lead in.
+        """
+
+        data_size = self._get_chunk_size()
+
+        total_data_size = self.next_segment_offset - self.raw_data_offset
+        if data_size < 0 or total_data_size < 0:
+            raise ValueError("Negative data size")
+        elif data_size == 0:
+            # Sometimes kTocRawData is set, but there isn't actually any data
+            if total_data_size != data_size:
+                raise ValueError(
+                    "Zero channel data size but data length based on "
+                    "segment offset is %d." % total_data_size)
+            self.num_chunks = 0
+            return
+        chunk_remainder = total_data_size % data_size
+        if chunk_remainder == 0:
+            self.num_chunks = int(total_data_size // data_size)
+        else:
+            log.warning(
+                "Data size %d is not a multiple of the "
+                "chunk size %d. Will attempt to read last chunk",
+                total_data_size, data_size)
+            self.num_chunks = 1 + int(total_data_size // data_size)
+            self.final_chunk_proportion = (
+                    float(chunk_remainder) / float(data_size))
+
+    def _new_segment_object(self, object_path, raw_data_index_header):
+        """ Create a new segment object for a segment
+
+        :param object_path: Path for the object
+        :param raw_data_index_header: Integer raw data index header value
+        """
+        if raw_data_index_header in (FORMAT_CHANGING_SCALER, DIGITAL_LINE_SCALER):
+            return DaqmxSegmentObject(object_path, self.endianness)
         return TdmsSegmentObject(object_path, self.endianness)
 
+    def _get_chunk_size(self):
+        if self._have_daqmx_objects():
+            return get_daqmx_chunk_size(self.ordered_objects)
+        return sum([
+            o.data_size
+            for o in self.ordered_objects if o.has_data])
+
     def _read_data_chunks(self, file, data_objects, num_chunks):
+        """ Read multiple data chunks at once
+            In the base case we read each chunk individually but subclasses can override this
+        """
+        reader = self._get_data_reader()
+        for chunk in reader.read_data_chunks(file, data_objects, num_chunks):
+            yield chunk
+
+    def _read_channel_data_chunks(self, file, data_objects, channel_path, chunk_offset, stop_chunk):
+        """ Read multiple data chunks for a single channel at once
+            In the base case we read each chunk individually but subclasses can override this
+        """
+        reader = self._get_data_reader()
+        for chunk in reader.read_channel_data_chunks(file, data_objects, channel_path, chunk_offset, stop_chunk):
+            yield chunk
+
+    def _get_data_reader(self):
+        if self._have_daqmx_objects():
+            return DaqmxDataReader(self.num_chunks, self.final_chunk_proportion, self.endianness)
+        elif self.toc_mask & toc_properties['kTocInterleavedData']:
+            return InterleavedDataReader(self.num_chunks, self.final_chunk_proportion, self.endianness)
+        else:
+            return ContiguousDataReader(self.num_chunks, self.final_chunk_proportion, self.endianness)
+
+    def _have_daqmx_objects(self):
+        is_daqmx = [isinstance(o, DaqmxSegmentObject) for o in self.ordered_objects if o.has_data]
+        if len(is_daqmx) == 0:
+            return False
+        if all(is_daqmx):
+            return True
+        if any(is_daqmx):
+            raise Exception("Cannot read mixed DAQmx and non-DAQmx data")
+        return False
+
+
+class InterleavedDataReader(BaseDataReader):
+    """ Reads data in a TDMS segment with interleaved data
+    """
+
+    def read_data_chunks(self, file, data_objects, num_chunks):
         """ Read multiple data chunks at once
         """
         # If all data types are sized and all the lengths are
@@ -39,12 +352,12 @@ class InterleavedDataSegment(BaseSegment):
         else:
             return [self._read_interleaved(file, data_objects, num_chunks)]
 
-    def _read_channel_data_chunks(self, file, data_objects, channel_path, chunk_offset, stop_chunk):
+    def read_channel_data_chunks(self, file, data_objects, channel_path, chunk_offset, stop_chunk):
         """ Read multiple data chunks for a single channel at once
         """
         num_chunks = stop_chunk - chunk_offset
-        all_chunks = self._read_data_chunks(file, data_objects, num_chunks)
-        return [BaseSegment._data_chunk_to_channel_chunk(chunk, channel_path) for chunk in all_chunks]
+        all_chunks = self.read_data_chunks(file, data_objects, num_chunks)
+        return [data_chunk_to_channel_chunk(chunk, channel_path) for chunk in all_chunks]
 
     def _read_data_chunk(self, file, data_objects, chunk_index):
         """ Not used for interleaved data, multiple chunks are read at once
@@ -105,14 +418,9 @@ class InterleavedDataSegment(BaseSegment):
         return RawDataChunk.channel_data(object_data)
 
 
-class ContiguousDataSegment(BaseSegment):
-    """ A TDMS segment with contiguous (non-interleaved) data
+class ContiguousDataReader(BaseDataReader):
+    """ Reads data in a TDMS segment with contiguous (non-interleaved) data
     """
-
-    __slots__ = []
-
-    def _new_segment_object(self, object_path):
-        return TdmsSegmentObject(object_path, self.endianness)
 
     def _read_data_chunk(self, file, data_objects, chunk_index):
         log.debug("Reading contiguous data chunk")
@@ -218,3 +526,13 @@ class TdmsSegmentObject(BaseSegmentObject):
             return np.zeros(self.number_values, dtype=self.data_type.nptype)
         else:
             return [None] * self.number_values
+
+
+def read_property(f, endianness="<"):
+    """ Read a property from a segment's metadata """
+
+    prop_name = types.String.read(f, endianness)
+    prop_data_type = types.tds_data_types[types.Uint32.read(f, endianness)]
+    value = prop_data_type.read(f, endianness)
+    log.debug("Property '%s' = %r", prop_name, value)
+    return prop_name, value

--- a/nptdms/test/test_scaling.py
+++ b/nptdms/test/test_scaling.py
@@ -545,6 +545,24 @@ def test_scaling_status_scaled():
     assert scaling is None
 
 
+def test_advanced_api_scaling():
+    """Test AdvancedAPI scaling (no-op)"""
+
+    data = StubTdmsData(np.array([1, 2, 3], dtype=np.dtype('int32')))
+    expected_scaled_data = np.array([1, 2, 3])
+
+    properties = {
+        "NI_Number_Of_Scales": 1,
+        "NI_Scale[0]_Scale_Type": "AdvancedAPI",
+    }
+    scaling = get_scaling(properties, {}, {})
+    scaled_data = scaling.scale(data)
+
+    assert scaling.get_dtype(types.Int32, None) == np.dtype('int32')
+    assert scaled_data.dtype == np.dtype('int32')
+    np.testing.assert_almost_equal(scaled_data, expected_scaled_data)
+
+
 class StubTdmsData(object):
     def __init__(self, data):
         self.data = data

--- a/nptdms/types.py
+++ b/nptdms/types.py
@@ -86,6 +86,7 @@ class Bytes(TdmsType):
 
 class StructType(TdmsType):
     struct_declaration = None
+    nptype = None
 
     def __init__(self, value):
         self.value = value
@@ -95,6 +96,14 @@ class StructType(TdmsType):
     def read(cls, file, endianness="<"):
         read_bytes = file.read(cls.size)
         return _struct_unpack(endianness + cls.struct_declaration, read_bytes)[0]
+
+    @classmethod
+    def from_bytes(cls, byte_array, endianness="<"):
+        """ Convert an array of bytes into a numpy array of data
+        """
+        array = byte_array.view()
+        array.dtype = cls.nptype.newbyteorder(endianness)
+        return array
 
 
 @tds_data_type(0, None)


### PR DESCRIPTION
This fixes reading the files in issue #226 

I had previously assumed that only segments with the `kTocDAQmxRawData` flag would contain metadata in DAQmx format, so the type of the segment was driven from the ToC flags. Now all segments are handled by the `TdmsSegment` class, which chooses the type of object metadata based on the raw data index header, and new classes for reading different types of segment data have been added (`DaqmxDataReader`, `InterleavedDataReader` and `ContiguousDataReader`).

I'd also assumed that all segments using DAQmx metadata would have a data type of `DaqMxRawData`, whereas these files have integer, floating point and timestamp data. With this change we now verify that the scaler data type matches the channel type and there is only a single scaler when the channel data type is not `DaqMxRawData`. I've also added support for some missing DAQmx data types (int64, uint64, float32, float64 and timestamp).

The DAQmx reading code also assumed that all channels in a segment had the same chunk size, but now we allow different data buffers in the same segment to have different chunk sizes.

These channels also have an `AdvancedAPI` scaling without any associated scaling properties, which doesn't appear to apply any actual scaling, so I've added a `NoOpScaling` to handle this so a warning isn't logged.