### PR TITLE
Reduce memory usage for channel indexes in open mode

### DIFF
--- a/nptdms/reader.py
+++ b/nptdms/reader.py
@@ -241,12 +241,11 @@ class TdmsReader(object):
             raise ValueError(
                 "Segment does not start with %r, but with %r" % (expected_tag, tag))
 
-        log.debug("Reading segment at %d", segment_position)
-
         # Next four bytes are table of contents mask
         toc_mask = types.Int32.read(file)
 
         if log.isEnabledFor(logging.DEBUG):
+            log.debug("Reading segment at %d", segment_position)
             for prop_name, prop_mask in toc_properties.items():
                 prop_is_set = (toc_mask & prop_mask) != 0
                 log.debug("Property %s is %s", prop_name, prop_is_set)
@@ -274,10 +273,8 @@ class TdmsReader(object):
             next_segment_pos = self._get_data_file_size()
             next_segment_offset = next_segment_pos - segment_position - lead_size
         else:
-            log.debug("Next segment offset = %d, raw data offset = %d",
-                      next_segment_offset, raw_data_offset)
-            log.debug("Data size = %d b",
-                      next_segment_offset - raw_data_offset)
+            log.debug("Next segment offset = %d, raw data offset = %d, data size = %d b",
+                      next_segment_offset, raw_data_offset, next_segment_offset - raw_data_offset)
             next_segment_pos = (
                     segment_position + next_segment_offset + lead_size)
 

--- a/nptdms/reader.py
+++ b/nptdms/reader.py
@@ -349,8 +349,9 @@ class TdmsReader(object):
             # Get number of values for this channel in each segment
             segment_num_values = np.zeros(num_segments, dtype=np.int64)
             for i, segment in enumerate(self._segments):
-                segment_obj = segment.get_segment_object(obj_path)
-                if segment_obj is not None:
+                obj_index = segment.object_index.get(obj_path)
+                if obj_index is not None:
+                    segment_obj = segment.ordered_objects[obj_index]
                     segment_num_values[i] = _number_of_segment_values(segment_obj, segment)
             # Now use the cumulative sum to get the total channel value count
             # at the end of each segment.

--- a/nptdms/reader.py
+++ b/nptdms/reader.py
@@ -315,7 +315,8 @@ class TdmsReader(object):
             object_metadata = self._get_or_create_object(path)
             object_metadata.num_values += _number_of_segment_values(segment_object, segment)
             _update_object_data_type(path, object_metadata, segment_object)
-            _update_object_scaler_data_types(path, object_metadata, segment_object)
+            if segment_object.scaler_data_types is not None:
+                _update_object_scaler_data_types(path, object_metadata, segment_object)
 
     def _update_object_properties(self, segment):
         """ Update object properties using any properties in a segment
@@ -393,13 +394,12 @@ def _update_object_data_type(path, obj, segment_object):
 def _update_object_scaler_data_types(path, obj, segment_object):
     """ Update the DAQmx scaler data types for an object using its segment metadata
     """
-    if segment_object.scaler_data_types is not None:
-        if obj.scaler_data_types is not None and obj.scaler_data_types != segment_object.scaler_data_types:
-            raise ValueError(
-                "Segment data doesn't have the same scaler data types as previous "
-                "segments for objects %s. Expected types %s but got %s" %
-                (path, obj.scaler_data_types, segment_object.scaler_data_types))
-        obj.scaler_data_types = segment_object.scaler_data_types
+    if obj.scaler_data_types is not None and obj.scaler_data_types != segment_object.scaler_data_types:
+        raise ValueError(
+            "Segment data doesn't have the same scaler data types as previous "
+            "segments for objects %s. Expected types %s but got %s" %
+            (path, obj.scaler_data_types, segment_object.scaler_data_types))
+    obj.scaler_data_types = segment_object.scaler_data_types
 
 
 class ObjectMetadata(object):

--- a/nptdms/reader.py
+++ b/nptdms/reader.py
@@ -58,8 +58,10 @@ class TdmsReader(object):
         # Otherwise always remove reference to the file
         self._file = None
 
-    def read_metadata(self):
+    def read_metadata(self, require_segment_indexes=False):
         """ Read all metadata and structure information from a TdmsFile
+
+        :param require_segment_indexes: Whether to create segment object indexes to allow lookup of objects by path.
         """
         self._ensure_open()
 
@@ -76,7 +78,7 @@ class TdmsReader(object):
             with Timer(log, "Read metadata"):
                 # Read metadata first to work out how much space we need
                 previous_segment = None
-                index_cache = SegmentIndexCache()
+                index_cache = SegmentIndexCache() if require_segment_indexes else None
                 while True:
                     start_position = file.tell()
                     try:

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -127,7 +127,7 @@ class TdmsFile(object):
 
         self._reader = TdmsReader(file)
         try:
-            self._read_file(self._reader, read_metadata_only)
+            self._read_file(self._reader, read_metadata_only, keep_open)
         finally:
             if not keep_open:
                 self._reader.close()
@@ -222,8 +222,8 @@ class TdmsFile(object):
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
-    def _read_file(self, tdms_reader, read_metadata_only):
-        tdms_reader.read_metadata()
+    def _read_file(self, tdms_reader, read_metadata_only, keep_open):
+        tdms_reader.read_metadata(require_segment_indexes=keep_open)
 
         # Use object metadata to build group and channel objects
         group_properties = OrderedDict()

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -556,6 +556,8 @@ class ObjectListKey(object):
     """ Wraps a list of objects for using as a cache key, where we are only concerned with the object paths
     """
 
+    __slots__ = ['objects', '_hash']
+
     def __init__(self, objects):
         self.objects = objects
         hash_result = 0

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -379,10 +379,8 @@ class InterleavedDataReader(BaseDataReader):
     def _read_interleaved_sized(self, file, data_objects, num_chunks):
         """Read interleaved data where all channels have a sized data type and the same length
         """
-        log.debug("Reading interleaved data all at once")
-
         total_data_width = sum(o.data_type.size for o in data_objects)
-        log.debug("total_data_width: %d", total_data_width)
+        log.debug("Reading interleaved data all at once. total_data_width: %d", total_data_width)
 
         # Read all data into 1 byte unsigned ints first
         combined_data = read_interleaved_segment_bytes(

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -38,7 +38,7 @@ class TdmsSegment(object):
         'position', 'num_chunks', 'ordered_objects', 'toc_mask',
         'next_segment_offset', 'next_segment_pos',
         'raw_data_offset', 'data_position', 'final_chunk_proportion',
-        'endianness', 'object_properties']
+        'endianness', 'object_properties', 'object_index']
 
     def __init__(
             self, position, toc_mask, endianness, next_segment_offset,
@@ -52,18 +52,20 @@ class TdmsSegment(object):
         self.data_position = data_position
         self.num_chunks = 0
         self.final_chunk_proportion = 1.0
-        self.ordered_objects = []
+        self.ordered_objects = None
+        self.object_index = None
         self.object_properties = None
 
     def __repr__(self):
         return "<TdmsSegment at position %d>" % self.position
 
-    def read_segment_objects(self, file, previous_segment_objects, previous_segment=None):
+    def read_segment_objects(self, file, previous_segment_objects, index_cache, previous_segment=None):
         """Read segment metadata section and update object information
 
         :param file: Open TDMS file
         :param previous_segment_objects: Dictionary of path to the most
             recently read segment object for a TDMS object.
+        :param index_cache: A SegmentIndexCache instance
         :param previous_segment: Previous segment in the file.
         """
 
@@ -74,7 +76,10 @@ class TdmsSegment(object):
         endianness = self.endianness
 
         new_obj_list = self.toc_mask & toc_properties['kTocNewObjList']
-        if not new_obj_list:
+        if new_obj_list:
+            self.ordered_objects = []
+            existing_objects = None
+        else:
             # In this case, there can be a list of new objects that
             # are appended, or previous objects can also be repeated
             # if their properties change.
@@ -83,8 +88,6 @@ class TdmsSegment(object):
             self.ordered_objects = [
                 o for o in previous_segment.ordered_objects]
             existing_objects = {o.path: (i, o) for (i, o) in enumerate(self.ordered_objects)}
-        else:
-            existing_objects = None
 
         log.debug("Reading segment object metadata at %d", file.tell())
 
@@ -123,7 +126,15 @@ class TdmsSegment(object):
                     segment_obj.read_raw_data_index(file, raw_data_index_header)
 
             self._read_object_properties(file, object_path)
+        self.object_index = index_cache.get_index(self.ordered_objects)
         self._calculate_chunks()
+
+    def get_segment_object(self, object_path):
+        try:
+            obj_index = self.object_index[object_path]
+            return self.ordered_objects[obj_index]
+        except KeyError:
+            return None
 
     def _update_existing_object(
             self, object_path, existing_object_index, existing_object, raw_data_index_header, file):
@@ -176,6 +187,7 @@ class TdmsSegment(object):
     def _reuse_previous_segment_metadata(self, previous_segment):
         try:
             self.ordered_objects = previous_segment.ordered_objects
+            self.object_index = previous_segment.object_index
             self._calculate_chunks()
         except AttributeError:
             raise ValueError(
@@ -521,6 +533,44 @@ class TdmsSegmentObject(BaseSegmentObject):
             return np.zeros(self.number_values, dtype=self.data_type.nptype)
         else:
             return [None] * self.number_values
+
+
+class SegmentIndexCache(object):
+    """ Caches dictionaries for indexing segment object lists using object paths
+    """
+
+    def __init__(self):
+        self._indexes = {}
+
+    def get_index(self, object_list):
+        key = ObjectListKey(object_list)
+        try:
+            return self._indexes[key]
+        except KeyError:
+            index = dict((o.path, i) for (i, o) in enumerate(object_list))
+            self._indexes[key] = index
+            return index
+
+
+class ObjectListKey(object):
+    """ Wraps a list of objects for using as a cache key, where we are only concerned with the object paths
+    """
+
+    def __init__(self, objects):
+        self.objects = objects
+        hash_result = 0
+        for obj in objects:
+            # This is order independent, but it's unlikely that different segments
+            # would have the same objects but in a different order.
+            hash_result = hash_result ^ hash(obj.path)
+        self._hash = hash_result
+
+    def __eq__(self, other):
+        return len(self.objects) == len(other.objects) and all(
+            oa.path == ob.path for (oa, ob) in zip(self.objects, other.objects))
+
+    def __hash__(self):
+        return self._hash
 
 
 def read_property(f, endianness="<"):

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -65,7 +65,7 @@ class TdmsSegment(object):
         :param file: Open TDMS file
         :param previous_segment_objects: Dictionary of path to the most
             recently read segment object for a TDMS object.
-        :param index_cache: A SegmentIndexCache instance
+        :param index_cache: A SegmentIndexCache instance, or None if segment indexes are not required.
         :param previous_segment: Previous segment in the file.
         """
 
@@ -126,7 +126,8 @@ class TdmsSegment(object):
                     segment_obj.read_raw_data_index(file, raw_data_index_header)
 
             self._read_object_properties(file, object_path)
-        self.object_index = index_cache.get_index(self.ordered_objects)
+        if index_cache is not None:
+            self.object_index = index_cache.get_index(self.ordered_objects)
         self._calculate_chunks()
 
     def get_segment_object(self, object_path):

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -296,10 +296,10 @@ def test_indexing_channel_with_negative_integer(index):
                 assert channel_object[index] == expected_channel_data[index]
 
 
-def test_indexing_channel_with_integer_and_caching():
+@pytest.mark.parametrize("test_file,expected_data", scenarios.get_scenarios())
+def test_indexing_channel_with_integer_and_caching(test_file, expected_data):
     """ Test indexing into a channel with an integer index, reusing the same file to test caching
     """
-    test_file, expected_data = scenarios.chunked_segment().values
     with test_file.get_tempfile() as temp_file:
         with TdmsFile.open(temp_file.file) as tdms_file:
             for ((group, channel), expected_channel_data) in expected_data.items():


### PR DESCRIPTION
See issue #203 for context

This PR reduces the memory usage used when indexing channels for data reading after using `TdmsFile.open`

* Add a per-segment index from object path to index in the objects array. These can be re-used across segments so shouldn't increase memory usage much in most cases, but the time taken for the initial `TdmsFile.Open` call will increase slightly (around 10% increase from my testing with a file where the segment objects alternate in each segment).
* This allows us to completely get rid of the `_segment_chunk_sizes` property, halving the index memory usage.
* De-duplicate the `_segment_channel_offsets` arrays as described above. In my test example this brings memory usage from around 100 MB (after removing `_segment_chunk_sizes`) to 1 MB, but this will depend a lot on the file structure.
* Build an index per-channel as required rather than all channels at once. So if you don't read data from all channels you don't pay the CPU and memory cost of building the index. And if you're working interactively you don't have a big wait to build all indexes at once on the first read.
* Trim the index arrays to the range of segments that contain data for a channel