### PR TITLE
Use file.readinto instead of np.fromfile when reading data

### DIFF
--- a/nptdms/base_segment.py
+++ b/nptdms/base_segment.py
@@ -137,14 +137,19 @@ class RawChannelDataChunk(object):
 
 
 def fromfile(file, dtype, count, *args, **kwargs):
-    """Wrapper around np.fromfile to support any file-like object"""
+    """Read from any file-like object into a numpy array"""
 
-    try:
-        return np.fromfile(file, dtype=dtype, count=count, *args, **kwargs)
-    except (TypeError, IOError, UnsupportedOperation):
-        return np.frombuffer(
-            file.read(int(count * np.dtype(dtype).itemsize)),
-            dtype=dtype, count=count, *args, **kwargs)
+    itemsize = np.dtype(dtype).itemsize
+    buffer = np.zeros(count * itemsize, np.uint8)
+    bytes_read = -1
+    offset = 0
+    while bytes_read != 0:
+        bytes_read = file.readinto(buffer[offset:])
+        offset += bytes_read
+    rounded_bytes = (offset // itemsize) * itemsize
+    buffer = buffer[:rounded_bytes]
+    buffer.dtype = dtype
+    return buffer
 
 
 def read_interleaved_segment_bytes(f, bytes_per_row, num_values):


### PR DESCRIPTION
This is to avoid poor performance of `np.fromfile` in Python 3, and should help with #249