### PR TITLE
Pin dependency versions used by readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+version: 2
+
+# Build from the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Explicitly set the version of Python and its requirements
+python:
+  version: 3.8
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.abspath('..'))
 extensions = ["sphinx.ext.autodoc"]
 
 # Autodoc options
-autoclass_content = "doc"
+autoclass_content = "class"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = []

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==4.2.0
+sphinx_rtd_theme==1.0.0
+readthedocs-sphinx-search==0.1.1


### PR DESCRIPTION
Use a newer version of Sphinx than the default used in readthedocs to fix the current build failure: https://readthedocs.org/projects/nptdms/builds/15110615/