### PR TITLE
Migrate to setup.cfg and pyproject.toml

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10', '3.11']
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/nptdms/version.py
+++ b/nptdms/version.py
@@ -1,2 +1,5 @@
-__version_info__ = (1, 6, 1)
-__version__ = '.'.join('%d' % d for d in __version_info__)
+from importlib import metadata
+
+
+__version__ = metadata.version('nptdms')
+__version_info__ = tuple(int(x) for x in __version__.split('.'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+    "setuptools",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,48 @@
+[metadata]
+name = npTDMS
+version = 1.6.2
+description = Cross-platform, NumPy based module for reading TDMS files produced by LabView
+author = Adam Reeve
+author_email = adreeve@gmail.com
+url = https://github.com/adamreeve/npTDMS
+long_description = file: README.rst
+license = LGPL
+classifiers =
+  Development Status :: 5 - Production/Stable
+  Operating System :: OS Independent
+  Programming Language :: Python
+  Programming Language :: Python :: 3
+  Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
+  Topic :: Scientific/Engineering
+  License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)
+  Intended Audience :: Science/Research
+  Natural Language :: English
+
+[options]
+packages =
+    nptdms
+    nptdms.export
+    nptdms.test
+install_requires =
+    numpy
+
+[options.entry_points]
+console_scripts =
+    tdmsinfo = nptdms.tdmsinfo:main
+
+[options.extras_require]
+test =
+    pytest >= 3.1.0
+    hypothesis
+    pytest-benchmark
+    thermocouples_reference
+    scipy
+pandas =
+    pandas
+hdf =
+    h5py >= 2.10.0
+thermocouple_scaling =
+

--- a/setup.py
+++ b/setup.py
@@ -1,57 +1,7 @@
-import os
+#!/usr/bin/env python
 
 from setuptools import setup
 
 
-def read_version():
-    here = os.path.abspath(os.path.dirname(__file__))
-    version_path = os.path.sep.join((here, "nptdms", "version.py"))
-    v_globals = {}
-    v_locals = {}
-    exec(open(version_path).read(), v_globals, v_locals)
-    return v_locals['__version__']
-
-
-setup(
-  name = 'npTDMS',
-  version = read_version(),
-  description = ("Cross-platform, NumPy based module for reading "
-    "TDMS files produced by LabView."),
-  author = 'Adam Reeve',
-  author_email = 'adreeve@gmail.com',
-  url = 'https://github.com/adamreeve/npTDMS',
-  packages = ['nptdms', 'nptdms.export', 'nptdms.test'],
-  long_description=open('README.rst').read(),
-  license = 'LGPL',
-  classifiers = [
-    'Development Status :: 4 - Beta',
-    'Operating System :: OS Independent',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
-    'Topic :: Scientific/Engineering',
-    'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
-    'Intended Audience :: Science/Research',
-    'Natural Language :: English',
-  ],
-  install_requires = ['numpy'],
-  extras_require = {
-      'test': [
-          'pytest>=3.1.0',
-          'hypothesis',
-          'pytest-benchmark',
-          'thermocouples_reference',
-          'scipy',
-      ],
-      'pandas': ['pandas'],
-      'hdf': ['h5py>=2.10.0'],
-      'thermocouple_scaling': [],  # Kept for backwards compatibility
-  },
-  entry_points = """
-  [console_scripts]
-  tdmsinfo=nptdms.tdmsinfo:main
-  """
-)
+if __name__ == '__main__':
+    setup()


### PR DESCRIPTION
Fixes #298

Drops Python 3.7 support due to using `importlib.metadata`