### PR TITLE
Fix building the documentation on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,3 +11,5 @@ sphinx:
 python:
   install:
     - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ build:
 
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,13 @@
 version: 2
 
-# Build from the docs/ directory with Sphinx
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: docs/conf.py
 
-# Explicitly set the version of Python and its requirements
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,13 +11,13 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys
 import configparser
+from pathlib import Path
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('..'))
+# Allow importing nptdms from the parent directory for building API docs
+repo_root = Path(__file__).parent.parent
+sys.path.insert(0, str(repo_root))
 
 # -- General configuration -----------------------------------------------------
 
@@ -52,7 +52,7 @@ copyright = u'Adam Reeve'
 # built documents.
 #
 setup_cfg = configparser.ConfigParser()
-setup_cfg.read('../setup.cfg')
+setup_cfg.read(repo_root / 'setup.cfg')
 # The short X.Y version.
 version = '.'.join(setup_cfg['metadata']['version'].split('.')[:2])
 # The full version, including alpha/beta/rc tags.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'npTDMS'
-copyright = u'2012, Adam Reeve'
+copyright = u'Adam Reeve'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
For some reason importing nptdms by modifying `sys.path` stopped working in readthedocs. The current readthedocs documentation recommends installing the package with pip in the readthedocs python configuration, which fixed the issue.

This also fixes a few other things like adding the `build.os` configuration option which is now required, and failing the builds on warnings so that issues like this are more visible in future.

Fixes #309