### PR TITLE
Fix reading truncated data when the next segment offset is set

### DIFF
--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -482,6 +482,20 @@ def test_read_with_index_file(test_file, expected_data):
         compare_arrays(channel_obj.data, expected_channel_data)
 
 
+def test_read_index_file_only():
+    """ Test reading the index file directly
+    """
+    test_file, expected_data = scenarios.single_segment_with_two_channels().values
+    with test_file.get_tempfile_with_index() as tdms_file_path:
+        with TdmsFile.open(tdms_file_path + "_index") as tdms_file:
+            for ((group, channel), expected_channel_data) in expected_data.items():
+                channel_obj = tdms_file[group][channel]
+                assert len(channel_obj) == len(expected_channel_data)
+                with pytest.raises(RuntimeError) as exc_info:
+                    channel_obj[:]
+                assert "Data cannot be read from index file only" in str(exc_info.value)
+
+
 @pytest.mark.skipif(sys.version_info < (3, 4), reason="pathlib only available in stdlib since 3.4")
 def test_read_file_passed_as_pathlib_path():
     """ Test reading a file when using a pathlib Path object

--- a/nptdms/test/util.py
+++ b/nptdms/test/util.py
@@ -223,7 +223,9 @@ class GeneratedFile(object):
     def __init__(self):
         self._content = []
 
-    def add_segment(self, toc, metadata, data, incomplete=False, binary_data=False, version=4713):
+    def add_segment(
+            self, toc, metadata, data, incomplete=False, binary_data=False, version=4713,
+            data_size_override=None):
         metadata_bytes = _hex_to_bytes(metadata)
         data_bytes = data if binary_data else _hex_to_bytes(data)
         if toc is not None:
@@ -246,7 +248,8 @@ class GeneratedFile(object):
                     raise ValueError("Unrecognised TOC value: %s" % toc_item)
             lead_in += struct.pack('<i', toc_mask)
             lead_in += struct.pack('<l', version)
-            next_segment_offset = len(metadata_bytes) + len(data_bytes)
+            data_len = data_size_override if data_size_override is not None else len(data_bytes)
+            next_segment_offset = len(metadata_bytes) + data_len
             raw_data_offset = len(metadata_bytes)
             if incomplete:
                 lead_in += _hex_to_bytes('FF' * 8)


### PR DESCRIPTION
Fixes #317

The current logic for checking for truncated segments only checked whether the next segment offset was set to `0xFFFFFFFFFFFFFFFF`, but it's also possible that the next segment offset could be beyond the end of the file, which would cause the channel length to be calculated incorrectly and result in zero padded data when reading all values and finding that the number of bytes expected couldn't be read.