### PR TITLE
Expose information about incomplete final segments

### DIFF
--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -27,6 +27,12 @@ Reading TDMS Files
 .. autoclass:: ChannelDataChunk()
   :members:
 
+.. autoclass:: nptdms.tdms.FileStatus()
+  :members:
+
+.. autoclass:: nptdms.tdms.ChannelSegmentStatus()
+  :members:
+
 Writing TDMS Files
 ------------------
 

--- a/nptdms/reader.py
+++ b/nptdms/reader.py
@@ -275,10 +275,10 @@ class TdmsReader(object):
             file, segment_position, is_index_file)
 
         segment = TdmsSegment(
-            position, toc_mask, next_segment_pos, data_position)
+            position, toc_mask, next_segment_pos, data_position, segment_incomplete)
 
         properties = segment.read_segment_objects(
-            file, self._prev_segment_objects, index_cache, previous_segment, segment_incomplete)
+            file, self._prev_segment_objects, index_cache, previous_segment)
         return segment, properties
 
     def _read_lead_in(self, file, segment_position, is_index_file=False):

--- a/nptdms/test/test_daqmx.py
+++ b/nptdms/test/test_daqmx.py
@@ -625,6 +625,22 @@ def test_incomplete_segment_with_different_length_buffers():
     np.testing.assert_array_equal(group["Channel5"][:], [5] * 2)
     np.testing.assert_array_equal(group["Channel6"][:], [6] * 2)
 
+    file_status = tdms_data.file_status
+    assert file_status.incomplete_final_segment
+    assert file_status.channel_statuses is not None
+    for channel in ["Channel1", "Channel2"]:
+        channel_status = file_status.channel_statuses[f"/'Group'/'{channel}'"]
+        assert channel_status.expected_length == 4
+        assert channel_status.read_length == 4
+    for channel in ["Channel3", "Channel4"]:
+        channel_status = file_status.channel_statuses[f"/'Group'/'{channel}'"]
+        assert channel_status.expected_length == 2
+        assert channel_status.read_length == 1
+    for channel in ["Channel5", "Channel6"]:
+        channel_status = file_status.channel_statuses[f"/'Group'/'{channel}'"]
+        assert channel_status.expected_length == 1
+        assert channel_status.read_length == 0
+
 
 def test_multiple_raw_data_buffers_with_scalers_split_across_buffers():
     """ DAQmx with scalers split across different raw data buffers


### PR DESCRIPTION
Related to #317, this lets users check whether the final segment of a TDMS file is incomplete or truncated, and for each channel, how much data was read compared to how much was expected to be in the last segment.