### PR TITLE
Drastic performance improvements for reads (#249)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage.xml
 .ipynb_checkpoints
 .vscode
 *.ipynb
+.idea
 
 # Wercker directories
 _builds

--- a/nptdms/base_segment.py
+++ b/nptdms/base_segment.py
@@ -56,14 +56,14 @@ class BaseDataReader(object):
         """
         raise NotImplementedError("Data chunk reading must be implemented in base classes")
 
-    def read_channel_data_chunks(self, file, data_objects, channel_path, chunk_offset, stop_chunk):
+    def read_channel_data_chunks(self, file, data_objects, channel_path, chunk_offset, stop_chunk, chunk_size):
         """ Read multiple data chunks for a single channel at once
             In the base case we read each chunk individually but subclasses can override this
         """
         for chunk_index in range(chunk_offset, stop_chunk):
-            yield self._read_channel_data_chunk(file, data_objects, chunk_index, channel_path)
+            yield self._read_channel_data_chunk(file, data_objects, chunk_index, channel_path, chunk_size)
 
-    def _read_channel_data_chunk(self, file, data_objects, chunk_index, channel_path):
+    def _read_channel_data_chunk(self, file, data_objects, chunk_index, channel_path, chunk_size):
         """ Read data from a chunk for a single channel
         """
         # In the base case we can read data for all channels

--- a/nptdms/base_segment.py
+++ b/nptdms/base_segment.py
@@ -56,14 +56,14 @@ class BaseDataReader(object):
         """
         raise NotImplementedError("Data chunk reading must be implemented in base classes")
 
-    def read_channel_data_chunks(self, file, data_objects, channel_path, chunk_offset, stop_chunk, chunk_size):
+    def read_channel_data_chunks(self, file, data_objects, channel_path, chunk_offset, stop_chunk):
         """ Read multiple data chunks for a single channel at once
             In the base case we read each chunk individually but subclasses can override this
         """
         for chunk_index in range(chunk_offset, stop_chunk):
-            yield self._read_channel_data_chunk(file, data_objects, chunk_index, channel_path, chunk_size)
+            yield self._read_channel_data_chunk(file, data_objects, chunk_index, channel_path)
 
-    def _read_channel_data_chunk(self, file, data_objects, chunk_index, channel_path, chunk_size):
+    def _read_channel_data_chunk(self, file, data_objects, chunk_index, channel_path):
         """ Read data from a chunk for a single channel
         """
         # In the base case we can read data for all channels

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -531,6 +531,8 @@ class ContiguousDataReader(BaseDataReader):
             elif obj.data_type.size is not None:
                 # In last chunk with reduced chunk size
                 current_position += obj.data_type.size * number_values
+            else:
+                raise Exception("Cannot skip over channel with unsized type in a truncated segment")
 
         return channel_data
 

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -279,7 +279,9 @@ class TdmsSegment(object):
         if chunk_offset > 0:
             f.seek(chunk_size * chunk_offset, os.SEEK_CUR)
         stop_chunk = self.num_chunks if num_chunks is None else num_chunks + chunk_offset
-        for chunk in self._read_channel_data_chunks(f, self._get_data_objects(), channel_path, chunk_offset, stop_chunk, chunk_size):
+        for chunk in self._read_channel_data_chunks(
+                f, self._get_data_objects(), channel_path, chunk_offset, stop_chunk, chunk_size
+        ):
             yield chunk
 
     def _calculate_chunks(self):
@@ -382,7 +384,9 @@ class TdmsSegment(object):
         """
         reader = self._get_data_reader()
         initial_position = file.tell()
-        for i, chunk in enumerate(reader.read_channel_data_chunks(file, data_objects, channel_path, chunk_offset, stop_chunk, chunk_size)):
+        for i, chunk in enumerate(reader.read_channel_data_chunks(
+                file, data_objects, channel_path, chunk_offset, stop_chunk, chunk_size
+        )):
             yield chunk
             file.seek(initial_position + (i + 1) * chunk_size)
 

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -539,7 +539,6 @@ class ContiguousDataReader(BaseDataReader):
                 # In last chunk with reduced chunk size
                 current_position += obj.data_type.size * number_values
 
-        file.seek(current_position)
         return channel_data
 
     def _get_channel_number_values(self, obj, chunk_index):

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -383,7 +383,7 @@ class TdmsSegment(object):
         reader = self._get_data_reader()
         initial_position = file.tell()
         for i, chunk in enumerate(reader.read_channel_data_chunks(
-                file, data_objects, channel_path, chunk_offset, stop_chunk, chunk_size
+                file, data_objects, channel_path, chunk_offset, stop_chunk
         )):
             yield chunk
             file.seek(initial_position + (i + 1) * chunk_size)
@@ -461,7 +461,7 @@ class InterleavedDataReader(BaseDataReader):
             raise ValueError("Cannot read interleaved data with different chunk sizes")
         return [self._read_interleaved_chunks(file, data_objects, num_chunks)]
 
-    def read_channel_data_chunks(self, file, data_objects, channel_path, chunk_offset, stop_chunk, chunk_size):
+    def read_channel_data_chunks(self, file, data_objects, channel_path, chunk_offset, stop_chunk):
         """ Read multiple data chunks for a single channel at once
         """
         num_chunks = stop_chunk - chunk_offset
@@ -513,7 +513,7 @@ class ContiguousDataReader(BaseDataReader):
             object_data[obj.path] = obj.read_values(file, number_values, self.endianness)
         return RawDataChunk.channel_data(object_data)
 
-    def _read_channel_data_chunk(self, file, data_objects, chunk_index, channel_path, chunk_size):
+    def _read_channel_data_chunk(self, file, data_objects, chunk_index, channel_path):
         """ Read data from a chunk for a single channel
         """
         channel_data = RawChannelDataChunk.empty()

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -142,7 +142,6 @@ class TdmsSegment(object):
         if index_cache is not None:
             self.object_index = index_cache.get_index(self.ordered_objects)
 
-        self._invalidate_cached_values()
         self._calculate_chunks()
         return properties
 
@@ -202,7 +201,6 @@ class TdmsSegment(object):
             segment_obj.has_data = True
             segment_obj.read_raw_data_index(file, raw_data_index_header, endianness)
         self.ordered_objects.append(segment_obj)
-        self._invalidate_cached_values()
 
     def _reuse_previous_segment_metadata(self, previous_segment):
         try:
@@ -446,11 +444,6 @@ class TdmsSegment(object):
 
         self.data_objects_cached = [o for o in self.ordered_objects if o.has_data]
         return self.data_objects_cached
-
-    def _invalidate_cached_values(self):
-        self.has_daqmx_objects_cached = None
-        self.chunk_size_cached = None
-        self.data_objects_cached = None
 
 
 class InterleavedDataReader(BaseDataReader):

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -537,7 +537,7 @@ class ContiguousDataReader(BaseDataReader):
         return channel_data
 
     def _get_channel_number_values(self, obj, chunk_index):
-        if chunk_index == (self.num_chunks - 1) and self.final_chunk_lengths_override is not None:
+        if self.final_chunk_lengths_override is not None and chunk_index == (self.num_chunks - 1):
             return self.final_chunk_lengths_override.get(obj.path, 0)
         else:
             return obj.number_values


### PR DESCRIPTION
Possible solution for #249 .

See my comment [here](https://github.com/adamreeve/npTDMS/issues/249#issuecomment-2527946952).
Reading a file with thousands of signals partially can take a huge amount of time (100k signals read in slices, took 7000s).

I managed to greatly improve the performance by at least 12x (on 100k signals) to 25x (on 10k signals):
- caching
- skipping unneeded iterations over all data objects
- skipping unneeded file seeks

What is still a problem: the reading time still scales O(n²) with the amount on channels and chunks, because the channel has to be found by iterating through the list of data objects AND chunks.
If i read only 10k signals, the improvement factor is currently ~25x, for 100k signals it's only ~12x.

You see most of the time is now spent in the `_read_channel_data_chunk` and `_get_channel_number_values` functions. Once the channel is found, the search is ended (before it was iterating till the end). This mean for many signals the time to find the desired signal increases.
We need to find a way to calculate where the channel position is in order to greatly speed this up,
but i don't know the internals with chunking not well enough to do this.

Before:
![image](https://github.com/user-attachments/assets/495456d0-d4fb-4d7d-98e0-e435453852d0)

With my changes:
![image](https://github.com/user-attachments/assets/a8000682-8999-4264-82c2-685d8b2da967)
