### PR TITLE
Support reading and writing empty and/or void-type data segments

### DIFF
--- a/nptdms/channel_data.py
+++ b/nptdms/channel_data.py
@@ -20,16 +20,13 @@ def get_data_receiver(obj, num_values, raw_timestamps, memmap_dir=None):
     :param memmap_dir: Optional directory to store memory map files,
         or None to not use memory map files
     """
-    if obj.data_type is None:
-        return None
-
     if obj.data_type == types.DaqMxRawData:
         return DaqmxDataReceiver(obj, num_values, memmap_dir)
 
     if obj.data_type == types.TimeStamp:
         return TimestampDataReceiver(obj, num_values, raw_timestamps, memmap_dir)
 
-    if obj.data_type.nptype is None:
+    if obj.data_type is None or obj.data_type.nptype is None:
         return ListDataReceiver(obj)
 
     return NumpyDataReceiver(obj, num_values, memmap_dir)
@@ -59,7 +56,8 @@ class ListDataReceiver(object):
 
     @property
     def data(self):
-        return np.array(self._data, dtype=self._dtype)
+        dtype = self._dtype if len(self._data) > 0 else np.dtype('void')
+        return np.array(self._data, dtype=dtype)
 
 
 class NumpyDataReceiver(object):

--- a/nptdms/channel_data.py
+++ b/nptdms/channel_data.py
@@ -56,7 +56,7 @@ class ListDataReceiver(object):
 
     @property
     def data(self):
-        dtype = self._dtype if len(self._data) > 0 else np.dtype('void')
+        dtype = self._dtype if self._dtype is not None else np.dtype('V8')
         return np.array(self._data, dtype=dtype)
 
 

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -581,7 +581,7 @@ class TdmsChannel(object):
             return np.dtype('<M8[us]')
         if self.data_type is not None and self.data_type.nptype is not None:
             return self.data_type.nptype
-        return np.dtype('void')
+        return np.dtype('V8')
 
     @cached_property
     def data(self):

--- a/nptdms/tdms.py
+++ b/nptdms/tdms.py
@@ -581,7 +581,7 @@ class TdmsChannel(object):
             return np.dtype('<M8[us]')
         if self.data_type is not None and self.data_type.nptype is not None:
             return self.data_type.nptype
-        return np.dtype('V8')
+        return np.dtype('void')
 
     @cached_property
     def data(self):

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -584,7 +584,9 @@ class TdmsSegmentObject(BaseSegmentObject):
         if self.data_type == types.String:
             self.data_size = types.Uint64.read(f, endianness)
         elif self.number_values == 0:
-            return 0
+            # If there are no values, the data size is zero
+            # Avoid issues with empty arrays and void data where size is not defined
+            self.data_size = 0
         else:
             self.data_size = self.number_values * self.data_type.size
 

--- a/nptdms/tdms_segment.py
+++ b/nptdms/tdms_segment.py
@@ -569,9 +569,12 @@ class TdmsSegmentObject(BaseSegmentObject):
             self.data_type.__name__, self.number_values)
 
         if (self.data_type.size is None and
-                self.data_type != types.String):
+                self.data_type not in (types.String, types.Void)):
             raise ValueError(
                 "Unsupported data type: %r" % self.data_type)
+
+        if self.data_type == types.Void and self.number_values != 0:
+            raise ValueError("Void data only supported for empty segments")
 
         # In TDMS version 2.0, 1 is the only valid value for dimension
         if dimension != 1:
@@ -580,6 +583,8 @@ class TdmsSegmentObject(BaseSegmentObject):
         # Variable length data types have total size
         if self.data_type == types.String:
             self.data_size = types.Uint64.read(f, endianness)
+        elif self.number_values == 0:
+            return 0
         else:
             self.data_size = self.number_values * self.data_type.size
 

--- a/nptdms/test/scenarios.py
+++ b/nptdms/test/scenarios.py
@@ -951,7 +951,7 @@ def channel_without_data_or_data_type():
         ""
     )
     expected_data = {
-        ('group', 'channel1'): np.array([], dtype=np.dtype('void')),
+        ('group', 'channel1'): np.array([], dtype=np.dtype('V8')),
     }
     return test_file, expected_data
 

--- a/nptdms/test/test_tdms_file.py
+++ b/nptdms/test/test_tdms_file.py
@@ -52,10 +52,16 @@ def test_lazily_read_channel_data(test_file, expected_data):
                 compare_arrays(actual_data, expected_data)
 
 
-def test_read_raw_channel_data():
+@pytest.mark.parametrize(
+    "test_file,expected_data",
+    [
+        scenarios.single_segment_with_one_channel(),
+        scenarios.channel_without_data_or_data_type(),
+    ],
+)
+def test_read_raw_channel_data(test_file, expected_data):
     """Test reading raw channel data"""
 
-    test_file, expected_data = scenarios.single_segment_with_one_channel().values
     with test_file.get_tempfile() as temp_file:
         tdms_file = TdmsFile.read(temp_file.file)
         for ((group, channel), expected_data) in expected_data.items():

--- a/nptdms/test/writer/test_writer.py
+++ b/nptdms/test/writer/test_writer.py
@@ -565,6 +565,7 @@ def test_defragment_raw_timestamp_file():
             channel_data = f[group][channel][:]
             np.testing.assert_equal(channel_data, expected_values)
 
+
 def test_write_empty_void_data():
     data_file = BytesIO()
     with TdmsWriter(data_file) as file:

--- a/nptdms/test/writer/test_writer.py
+++ b/nptdms/test/writer/test_writer.py
@@ -9,6 +9,7 @@ import tempfile
 
 from nptdms import TdmsFile, TdmsWriter, RootObject, GroupObject, ChannelObject, types
 from nptdms.test import scenarios
+from nptdms.test.util import compare_arrays
 
 
 def test_can_read_tdms_file_after_writing():
@@ -563,3 +564,18 @@ def test_defragment_raw_timestamp_file():
         for (group, channel), expected_values in expected_data.items():
             channel_data = f[group][channel][:]
             np.testing.assert_equal(channel_data, expected_values)
+
+def test_write_empty_void_data():
+    data_file = BytesIO()
+    with TdmsWriter(data_file) as file:
+        file.write_segment([
+            RootObject(properties={"file": "file1"}),
+            GroupObject("group1"),
+            ChannelObject("group1", "channel1", np.array([], dtype='void'))
+        ])
+
+    data_file.seek(0, 0)
+    with TdmsFile.open(data_file) as tdms_file:
+        channel_data = tdms_file["group1"]["channel1"].data
+        assert channel_data.dtype == np.dtype('void')
+        compare_arrays(channel_data, np.array([], dtype=np.dtype('void')))

--- a/nptdms/test/writer/test_writer.py
+++ b/nptdms/test/writer/test_writer.py
@@ -571,11 +571,11 @@ def test_write_empty_void_data():
         file.write_segment([
             RootObject(properties={"file": "file1"}),
             GroupObject("group1"),
-            ChannelObject("group1", "channel1", np.array([], dtype='void'))
+            ChannelObject("group1", "channel1", np.array([], dtype='V8'))
         ])
 
     data_file.seek(0, 0)
     with TdmsFile.open(data_file) as tdms_file:
         channel_data = tdms_file["group1"]["channel1"].data
-        assert channel_data.dtype == np.dtype('void')
-        compare_arrays(channel_data, np.array([], dtype=np.dtype('void')))
+        assert channel_data.dtype == np.dtype('V8')
+        compare_arrays(channel_data, np.array([], dtype=np.dtype('V8')))

--- a/nptdms/writer.py
+++ b/nptdms/writer.py
@@ -438,6 +438,11 @@ def write_string_values(file, strings):
 
 
 def object_data_size(data_type, data_values):
+    if len(data_values) == 0:
+        # If there are no values, the size is 0
+        # Avoids issue with data_type void and empty values
+        return 0
+
     if data_type == String:
         # For string data, the total size is 8 bytes per string for the
         # offsets to the start of each string, plus the length of each string.


### PR DESCRIPTION
Fixes #346 

Add two tests:
* Read a TDMS file containing an empty channel (no data) that has no data type also
* Write and read back a segment with the void data type and no data

When reading a channel without data and without datatype, the returned value will be an empty numpy array of type `void`.

Void-type segments to be written must be empty (0 length data), otherwise an exception will be raised.