### PR TITLE
Fix comment typo in half bridge I configuration

### DIFF
--- a/nptdms/scaling.py
+++ b/nptdms/scaling.py
@@ -242,7 +242,7 @@ class StrainScaling(object):
         elif self.configuration == StrainScaling.HALF_BRIDGE_1:
             # In the half bridge type I configuration:
             # R1 = R2 = R0
-            # R3 = R0 (1 + ε ν G)
+            # R3 = R0 (1 - ε ν G)
             # R4 = R0 (1 + ε G)
             # Which gives Vo = [(1 - ε ν G) / (2 + ε G - ε ν G) - 1/2] Vex
             # Rearranging for strain:

--- a/nptdms/scaling.py
+++ b/nptdms/scaling.py
@@ -257,6 +257,13 @@ class StrainScaling(object):
             strain /= temp
             return strain
         elif self.configuration == StrainScaling.HALF_BRIDGE_2:
+            # In the half bridge type II configuration:
+            # R1 = R2 = R0
+            # R3 = R0 (1 - ε G)
+            # R4 = R0 (1 + ε G)
+            # This gives Vo = - ε G Vex / 2
+            # Rearrange for strain:
+            # ε = -2 Vo / (Vex G)
             lead_adjustment = 1.0 / (1.0 + self.lead_wire_resistance / self.gage_resistance)
             strain = voltage_out
             strain *= -2.0 * self.gain_adjustment / (


### PR DESCRIPTION
Really minor thing that doesn't make any difference to the actual function but it was really confusing me for a while so I thought I'd fix it – looks ilke a simple typo in this one line, the substitution and rearrangement equations are still correct, as is the calculation itself.

Screenshot of NI page:

<img width="1091" height="781" alt="image" src="https://github.com/user-attachments/assets/c7275698-926a-4db8-9dab-017f11f2df04" />

(From https://www.ni.com/en/shop/data-acquisition/sensor-fundamentals/measuring-strain-with-strain-gages.html#toc1)