### PR TITLE
Add back empty thermocouple_scaling feature for backwards compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ pandas = [
 hdf = [
     "h5py >= 2.10.0",
 ]
+thermocouple_scaling = []
 
 [project.urls]
 Documentation = "https://npTDMS.readthedocs.io"


### PR DESCRIPTION
This was lost in #350 but I'm not sure why it didn't cause a failure previously.