### PR TITLE
Fix numpy 2.0 compatibility

### DIFF
--- a/nptdms/daqmx.py
+++ b/nptdms/daqmx.py
@@ -214,7 +214,7 @@ class DaqMxMetadata(object):
         # There is one element per acquisition card, as data is interleaved
         # separately for each card.
         raw_data_widths_length = types.Uint32.read(f, endianness)
-        self.raw_data_widths = np.zeros(raw_data_widths_length, dtype=np.int32)
+        self.raw_data_widths = np.zeros(raw_data_widths_length, dtype=np.uint32)
         for width_idx in range(raw_data_widths_length):
             self.raw_data_widths[width_idx] = types.Uint32.read(f, endianness)
 

--- a/nptdms/export/hdf_export.py
+++ b/nptdms/export/hdf_export.py
@@ -92,5 +92,5 @@ def _hdf_attr_value(value):
     """ Convert a value into a format suitable for an HDF attribute
     """
     if isinstance(value, np.datetime64):
-        return np.string_(np.datetime_as_string(value, unit='us', timezone='UTC'))
+        return np.bytes_(np.datetime_as_string(value, unit='us', timezone='UTC'))
     return value

--- a/nptdms/test/scenarios.py
+++ b/nptdms/test/scenarios.py
@@ -600,7 +600,7 @@ def incomplete_last_row_of_interleaved_data():
 def bool_data():
     """ Test reading a file with boolean valued data
     """
-    expected_channel_data = np.array([False, True, False, True], dtype=np.dtype('bool8'))
+    expected_channel_data = np.array([False, True, False, True], dtype=np.dtype('bool'))
 
     test_file = GeneratedFile()
     test_file.add_segment(

--- a/nptdms/test/test_daqmx.py
+++ b/nptdms/test/test_daqmx.py
@@ -1001,6 +1001,76 @@ def test_daqmx_debug_logging(caplog):
     assert "data_type=Int16" in caplog.text
 
 
+# Tests for numpy 2.0 compatibility fixes
+
+def test_daqmx_raw_data_widths_dtype_is_uint32():
+    """raw_data_widths must use uint32 so values > 2^31-1 don't overflow (numpy 2.0 fix)"""
+    import struct
+    from io import BytesIO
+    from nptdms.daqmx import DaqMxMetadata, FORMAT_CHANGING_SCALER
+    from nptdms import types
+
+    # Build a minimal byte stream that DaqMxMetadata.__init__ can parse:
+    # dimension (L) + chunk_size (Q) + scaler_vector_length (L) = 16 bytes,
+    # followed by one DaqMxScaler (20 bytes: 5 x uint32),
+    # then raw_data_widths_length (uint32) + one width value (uint32 > 2^31).
+    large_width = 2**31  # would silently overflow if dtype were int32
+    buf = BytesIO()
+    buf.write(struct.pack("<LQL", 1, 4, 1))       # dimension=1, chunk_size=4, scaler_count=1
+    # DaqMxScaler: data_type_code, raw_buffer_index, raw_byte_offset, sample_format_bitmap, scale_id
+    buf.write(struct.pack("<LLLLL", 3, 0, 0, 0, 0))  # type 3 = Int16
+    buf.write(struct.pack("<I", 1))               # raw_data_widths_length = 1
+    buf.write(struct.pack("<I", large_width))     # width value that overflows int32
+    buf.seek(0)
+
+    meta = DaqMxMetadata(buf, "<", FORMAT_CHANGING_SCALER, types.DaqMxRawData)
+    assert meta.raw_data_widths.dtype == np.dtype("uint32"), (
+        "raw_data_widths must be uint32 to avoid overflow with large values"
+    )
+    assert meta.raw_data_widths[0] == large_width
+
+
+def test_daqmx_i16_channel_reads_correct_values_numpy2():
+    """I16 DAQmx channel data is read correctly (exercises from_bytes numpy 2.0 path)"""
+    scaler_metadata = daqmx_scaler_metadata(0, 3, 0)
+    metadata = segment_objects_metadata(
+        root_metadata(),
+        group_metadata(),
+        daqmx_channel_metadata("Channel1", 4, [2], [scaler_metadata]))
+    data = (
+        "01 00"
+        "FF FF"
+        "7F 00"
+        "80 FF"
+    )
+
+    test_file = GeneratedFile()
+    test_file.add_segment(segment_toc(), metadata, data)
+    tdms_data = test_file.load()
+
+    result = tdms_data["Group"]["Channel1"].raw_data
+    assert result.dtype == np.int16
+    np.testing.assert_array_equal(result, [1, -1, 127, -128])
+
+
+def test_daqmx_i8_scaler_reads_correct_values_numpy2():
+    """I8 DAQmx scaler data is read correctly (Int8 was the type that triggered the original bug)"""
+    scaler_metadata = daqmx_scaler_metadata(0, 1, 0)
+    metadata = segment_objects_metadata(
+        root_metadata(),
+        group_metadata(),
+        daqmx_channel_metadata("Channel1", 4, [1], [scaler_metadata]))
+    data = "01 FF 7F 80"
+
+    test_file = GeneratedFile()
+    test_file.add_segment(segment_toc(), metadata, data)
+    tdms_data = test_file.load()
+
+    result = tdms_data["Group"]["Channel1"].raw_data
+    assert result.dtype == np.int8
+    np.testing.assert_array_equal(result, [1, -1, 127, -128])
+
+
 def segment_toc():
     return (
         "kTocMetaData", "kTocRawData", "kTocNewObjList", "kTocDAQmxRawData")

--- a/nptdms/test/test_types.py
+++ b/nptdms/test/test_types.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from nptdms import types
+from nptdms.types import StructType
 
 
 @pytest.mark.parametrize(
@@ -54,3 +55,62 @@ def test_timestamp_from_date():
     read_datetime = types.TimeStamp.read(data_file)
 
     assert expected_datetime == read_datetime.as_datetime64()
+
+
+# Tests for numpy 2.0 compatibility: StructType.from_bytes() must not use
+# the deprecated `array.dtype = ...` assignment (removed in numpy 2.0).
+
+@pytest.mark.parametrize("tdms_type,values", [
+    pytest.param(types.Int8,   [-128, -1, 0, 1, 127],              id="Int8"),
+    pytest.param(types.Int16,  [-32768, -1, 0, 1, 32767],          id="Int16"),
+    pytest.param(types.Int32,  [-(2**31), -1, 0, 1, 2**31 - 1],   id="Int32"),
+    pytest.param(types.Int64,  [-(2**63), -1, 0, 1, 2**63 - 1],   id="Int64"),
+    pytest.param(types.Uint8,  [0, 1, 127, 255],                   id="Uint8"),
+    pytest.param(types.Uint16, [0, 1, 32767, 65535],               id="Uint16"),
+    pytest.param(types.Uint32, [0, 1, 2**31 - 1, 2**32 - 1],      id="Uint32"),
+    pytest.param(types.Uint64, [0, 1, 2**63 - 1, 2**64 - 1],      id="Uint64"),
+    pytest.param(types.SingleFloat, [-1.0, 0.0, 1.0],              id="SingleFloat"),
+    pytest.param(types.DoubleFloat, [-1.0, 0.0, 1.0],              id="DoubleFloat"),
+])
+def test_from_bytes_little_endian(tdms_type, values):
+    """from_bytes produces correct values for little-endian data (numpy 2.0)"""
+    expected = np.array(values, dtype=tdms_type.nptype)
+    raw = np.frombuffer(expected.tobytes(), dtype=np.uint8)
+    result = tdms_type.from_bytes(raw, "<")
+    np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize("tdms_type,values", [
+    pytest.param(types.Int8,   [-128, -1, 0, 1, 127],           id="Int8"),
+    pytest.param(types.Int16,  [-32768, -1, 0, 1, 32767],       id="Int16"),
+    pytest.param(types.Int32,  [-(2**31), -1, 0, 1, 2**31 - 1], id="Int32"),
+    pytest.param(types.Uint8,  [0, 1, 127, 255],                id="Uint8"),
+    pytest.param(types.Uint16, [0, 1, 32767, 65535],            id="Uint16"),
+    pytest.param(types.Uint32, [0, 1, 2**31 - 1, 2**32 - 1],   id="Uint32"),
+    pytest.param(types.SingleFloat, [-1.0, 0.0, 1.0],           id="SingleFloat"),
+    pytest.param(types.DoubleFloat, [-1.0, 0.0, 1.0],           id="DoubleFloat"),
+])
+def test_from_bytes_big_endian(tdms_type, values):
+    """from_bytes produces correct values for big-endian data (numpy 2.0)"""
+    expected = np.array(values, dtype=tdms_type.nptype)
+    raw = np.frombuffer(expected.byteswap().tobytes(), dtype=np.uint8)
+    result = tdms_type.from_bytes(raw, ">")
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_from_bytes_int8_boundary_values():
+    """Int8.from_bytes handles boundary values correctly — original bug triggered on int8"""
+    values = np.array([-128, -1, 0, 1, 127], dtype=np.int8)
+    raw = np.frombuffer(values.tobytes(), dtype=np.uint8)
+    result = types.Int8.from_bytes(raw, "<")
+    assert result.dtype == np.dtype("int8")
+    np.testing.assert_array_equal(result, values)
+
+
+def test_from_bytes_uint32_large_values():
+    """Uint32.from_bytes handles values > 2^31 without overflow"""
+    values = np.array([2**31, 2**32 - 1], dtype=np.uint32)
+    raw = np.frombuffer(values.tobytes(), dtype=np.uint8)
+    result = types.Uint32.from_bytes(raw, "<")
+    assert result.dtype == np.dtype("uint32")
+    np.testing.assert_array_equal(result, values)

--- a/nptdms/types.py
+++ b/nptdms/types.py
@@ -227,6 +227,10 @@ class Boolean(StructType):
     size = 1
     struct_declaration = "b"
 
+    def __init__(self, value):
+        super(Boolean, self).__init__(int(value))
+        self.value = bool(value)
+
     @classmethod
     def read(cls, file, endianness="<"):
         return bool(super(Boolean, cls).read(file, endianness))

--- a/nptdms/types.py
+++ b/nptdms/types.py
@@ -222,7 +222,7 @@ class String(TdmsType):
         return strings
 
 
-@tds_data_type(0x21, np.bool8)
+@tds_data_type(0x21, np.bool_)
 class Boolean(StructType):
     size = 1
     struct_declaration = "b"

--- a/nptdms/types.py
+++ b/nptdms/types.py
@@ -101,9 +101,7 @@ class StructType(TdmsType):
     def from_bytes(cls, byte_array, endianness="<"):
         """ Convert an array of bytes into a numpy array of data
         """
-        array = byte_array.view()
-        array.dtype = cls.nptype.newbyteorder(endianness)
-        return array
+        return byte_array.view(cls.nptype.newbyteorder(endianness))
 
 
 @tds_data_type(0, None)

--- a/nptdms/writer.py
+++ b/nptdms/writer.py
@@ -318,8 +318,7 @@ def to_file(file, array):
     try:
         array.tofile(file)
     except (TypeError, IOError, UnsupportedOperation):
-        # tostring actually returns bytes
-        file.write(array.tostring())
+        file.write(array.tobytes())
 
 
 def write_values(file, array):


### PR DESCRIPTION
## Summary

- `Boolean.__init__`: `np.bool_` is no longer a subclass of `int` in numpy 2.0, causing `struct.pack` to raise `struct.error: required argument is not an integer`. Fix by converting to `int` before packing (preserving the original `bool` value on the instance).
- `writer.to_file`: `ndarray.tostring()` was removed in numpy 2.0. Replace with `ndarray.tobytes()` (identical behaviour, the old name was deprecated since numpy 1.9).

## Test plan

- [x] All existing tests pass with numpy 2.x (`pytest nptdms/test/ --ignore=nptdms/test/test_thermocouples.py`)
- Note: `test_thermocouples.py` failures are caused by an upstream issue in the `thermocouples_reference` package (`np.array(..., copy=False, order='A')` semantics changed in numpy 2.0) — not related to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)